### PR TITLE
typo: completion message

### DIFF
--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -1131,7 +1131,7 @@ pub fn stage2(opts: &Options) -> ! {
     if let Err(why) = raw_mount_balena(&s2_config.flash_dev) {
         error!("Failed to transfer files to balena OS, error: {:?}", why);
     } else {
-        info!("Migration succeded successfully");
+        info!("Migration completed successfully");
     }
 
     sync();


### PR DESCRIPTION
just a minor fix of the completion message so it makes sense.