### PR TITLE
Fix get_mem_info() on 32-bit systems

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -153,8 +153,11 @@ pub(crate) fn get_mem_info() -> Result<(u64, u64)> {
         // depending on the platform. We need the conversion for 32-bit
         // architectures, but clippy would complain about it in 64-bit ones.
         // Therefore, we suppress the warning.
-        #[allow(clippy::useless_conversion)]
-        Ok((s_info.totalram.into(), s_info.freeram.into()))
+        #[allow(clippy::unnecessary_cast)]
+        Ok((
+            (s_info.totalram as u64) * (s_info.mem_unit as u64),
+            (s_info.freeram as u64) * (s_info.mem_unit as u64),
+        ))
     } else {
         Err(Error::new(ErrorKind::NotImpl))
     }


### PR DESCRIPTION
Use units multiplier to calculate memory values. It may be >1 on systems with large memory.

Now shows expected memory values for an 8 GB Pi4 with 32-bit OS. Uses units multiplier of 4096.

```
2023-12-17 14:23:03 INFO  Preparing for takeover..
2023-12-17 14:23:03 INFO  Found 7966 MiB total, 7728 MiB free memory
...
2023-12-17 14:23:04 INFO  Takeover initiated successfully, please wait for the device to be reflashed and reboot
```
Fixes #45