### PR TITLE
Xavier AGX/NX SD/NX eMMC: Migration tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,6 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[profile.release]
+opt-level = "z"
+strip = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,3 +1696,4 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +199,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,12 +306,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -297,10 +337,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "futures-sink"
@@ -320,8 +382,11 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -345,6 +410,19 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gptman"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597ab39960252358b1b1a6c38c9f8680e1950a7c3a9cdfe511172f0878ce2d95"
+dependencies = [
+ "bincode",
+ "crc",
+ "nix",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "h2"
@@ -1208,6 +1286,8 @@ version = "0.1.4"
 dependencies = [
  "cfg-if 0.1.10",
  "flate2",
+ "futures",
+ "gptman",
  "lazy_static",
  "libc",
  "log",
@@ -1257,6 +1337,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1696,4 +1796,3 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ opt-level = "s"
 [dependencies.libc]
 version = "0.2.70"
 
+[dependencies.finder]
+version = "0.1"
+
 [dependencies.reqwest]
 version = "0.11.24"
 features = ["blocking", "json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+opt-level = "s"
+
 [dependencies]
 
 [dependencies.libc]
@@ -72,6 +75,7 @@ version = "0.4"
 raspberrypi3 = []
 raspberrypi4-64 = []
 intel-nuc = []
+jetson-xavier = []
 
 [dependencies.openssl]
 version = "0.10.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,13 @@ intel-nuc = []
 [dependencies.openssl]
 version = "0.10.63"
 features = ["vendored"]
+
+[dependencies.gptman]
+version = "1.0.2"
+
+# Required to get past "ambiguous name" errors in pin-project-internal v0.4.17.
+# See https://github.com/taiki-e/pin-project/issues/337
+# Problem was triggered by addition of gptman.
+# This package seems foundational and important to keep updated.
+[dependencies.futures]
+version = "0.3.30"

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -43,6 +43,8 @@ pub const BALENA_OS_NAME: &str = "balenaOS";
 pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connections/";
 pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
 
+pub const JETSON_XAVIER_HW_PART_FORCE_RO_FILE: &str = "/sys/block/mmcblk0boot0/force_ro";
+
 pub const SYS_EFI_DIR: &str = "/sys/firmware/efi";
 pub const SYS_EFIVARS_DIR: &str = "/sys/firmware/efi/efivars";
 

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -30,6 +30,8 @@ pub const BALENA_BOOT_FSTYPE: &str = "vfat";
 pub const BALENA_DATA_PART: &str = "resin-data";
 pub const BALENA_DATA_FSTYPE: &str = "ext4";
 
+pub const BALENA_ROOTA_FSTYPE: &str = "ext4";
+
 pub const OLD_ROOT_MP: &str = "/mnt/old_root";
 pub const BALENA_BOOT_MP: &str = "/mnt/balena-boot";
 pub const BALENA_PART_MP: &str = "/mnt/balena-part";
@@ -44,6 +46,14 @@ pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connecti
 pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
 
 pub const JETSON_XAVIER_HW_PART_FORCE_RO_FILE: &str = "/sys/block/mmcblk0boot0/force_ro";
+
+/* Hardware defined boot partition for Jetson AGX Xavier */
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER_NX: &str = "/dev/mtd0";
+
+/* Stage 2 destination file name for the boot blob */
+pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
+pub const BOOT_BLOB_NAME_JETSON_XAVIER_NX: &str = "boot0_mtdblock0.img";
 
 pub const SYS_EFI_DIR: &str = "/sys/firmware/efi";
 pub const SYS_EFIVARS_DIR: &str = "/sys/firmware/efi/efivars";

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -10,6 +10,7 @@ pub(crate) const BLKID_CMD: &str = "blkid";
 
 pub(crate) const EFIBOOTMGR_CMD: &str = "efibootmgr";
 pub(crate) const DD_CMD: &str = "dd";
+pub(crate) const MTD_DEBUG_CMD: &str = "mtd_debug";
 
 pub(crate) const TAR_CMD: &str = "tar";
 

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -35,6 +35,13 @@ pub const BALENA_BOOT_MP: &str = "/mnt/balena-boot";
 pub const BALENA_PART_MP: &str = "/mnt/balena-part";
 
 pub const SYSTEM_CONNECTIONS_DIR: &str = "system-connections";
+pub const SYSTEM_PROXY_DIR: &str = "system-proxy";
+
+pub const BALENA_DATA_MP: &str = "/mnt/data/";
+pub const BALENA_OS_NAME: &str = "balenaOS";
+
+pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connections/";
+pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
 
 pub const SYS_EFI_DIR: &str = "/sys/firmware/efi";
 pub const SYS_EFIVARS_DIR: &str = "/sys/firmware/efi/efivars";

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -1,8 +1,11 @@
 use log::{debug, error, trace};
+use std::fs::File;
 use std::io::{self, Read};
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::result;
+
+use gptman::GPT;
 
 use crate::common::{Error, ErrorKind, Result};
 
@@ -28,7 +31,7 @@ pub(crate) use plain_file::PlainFile;
 pub(crate) const DEF_BLOCK_SIZE: usize = 512;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum LabelType {
     GPT,
     Dos,
@@ -214,6 +217,12 @@ impl Disk {
         }
 
         Ok(mbr)
+    }
+
+    pub fn read_gpt(&mut self) -> gptman::Result<GPT> {
+        let mut f = File::open(self.get_image_file())?;
+        //let len = f.seek(SeekFrom::End(0))?;
+        GPT::find_from(&mut f)
     }
 }
 
@@ -483,7 +492,7 @@ mod test {
 
         // iterate up the path to find project root
         let ancestors: Vec<&Path> = test_path.ancestors().collect();
-        test_path = test_path.parent().unwrap();
+        //test_path = test_path.parent().unwrap();
 
         ancestors.iter().rev().find(|dir| {
             test_path = test_path.parent().unwrap();

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -475,6 +475,7 @@ impl<'a> Read for PartitionReader<'a> {
             }
         }
     }
+
 }
 
 #[cfg(test)]

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -286,7 +286,7 @@ impl<'a> PartitionIterator<'a> {
                     self.part_idx = 4;
                     self.get_extended_partition()
                 }
-                PartitionType::Fat | PartitionType::Linux => {
+                PartitionType::Fat | PartitionType::Linux | PartitionType::GPT => {
                     // return regular partition
                     self.index += 1;
                     self.part_idx += 1;

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -28,6 +28,14 @@ pub struct Options {
     #[structopt(
         short,
         long,
+        value_name = "BOOT0_IMAGE",
+        parse(from_os_str),
+        help = "Path to boot0.gz image"
+    )]
+    boot0_image: Option<PathBuf>,
+    #[structopt(
+        short,
+        long,
         value_name = "VERSION",
         help = "Version of balena-os image to download"
     )]
@@ -166,6 +174,21 @@ impl Options {
 
     pub fn image(&self) -> &Option<PathBuf> {
         &self.image
+    }
+
+    /* Function below should only be used on
+     - Jetson Xavier - boot0.img written to /dev/mmcblk0boot0
+     - Jetson Xavier NX eMMC - boot0.img written to /dev/mtdblock0
+     - Jetson Xavier NX SD - boot0.img written to /dev/mmcblk0boot0
+
+     Xavier NX devices will need to use flash_erase or mtd_debug for clearing and writing the QSPI
+    */
+    pub fn boot0_image(&self) -> PathBuf {
+        if let Some(boot0_image) = &self.boot0_image {
+            boot0_image.clone()
+        } else {
+            PathBuf::from("boot0.img")
+        }
     }
 
     pub fn version(&self) -> &str {

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -34,6 +34,14 @@ pub struct Options {
     )]
     boot0_image: Option<PathBuf>,
     #[structopt(
+        short = "p",
+        long = "--ldd-path",
+        value_name = "LDD_PATH",
+        parse(from_os_str),
+        help = "Path to ldd script"
+    )]
+    ldd_path: Option<PathBuf>,
+    #[structopt(
         short,
         long,
         value_name = "VERSION",
@@ -188,6 +196,14 @@ impl Options {
             boot0_image.clone()
         } else {
             PathBuf::from("boot0.img")
+        }
+    }
+
+    pub fn ldd_path(&self) -> PathBuf {
+        if let Some(ldd_path) = &self.ldd_path {
+            ldd_path.clone()
+        } else {
+            PathBuf::from("")
         }
     }
 

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -26,14 +26,6 @@ pub struct Options {
     )]
     image: Option<PathBuf>,
     #[structopt(
-        short,
-        long,
-        value_name = "BOOT0_IMAGE",
-        parse(from_os_str),
-        help = "Path to boot0.gz image"
-    )]
-    boot0_image: Option<PathBuf>,
-    #[structopt(
         short = "p",
         long = "--ldd-path",
         value_name = "LDD_PATH",
@@ -182,21 +174,6 @@ impl Options {
 
     pub fn image(&self) -> &Option<PathBuf> {
         &self.image
-    }
-
-    /* Function below should only be used on
-     - Jetson Xavier - boot0.img written to /dev/mmcblk0boot0
-     - Jetson Xavier NX eMMC - boot0.img written to /dev/mtdblock0
-     - Jetson Xavier NX SD - boot0.img written to /dev/mmcblk0boot0
-
-     Xavier NX devices will need to use flash_erase or mtd_debug for clearing and writing the QSPI
-    */
-    pub fn boot0_image(&self) -> PathBuf {
-        if let Some(boot0_image) = &self.boot0_image {
-            boot0_image.clone()
-        } else {
-            PathBuf::from("boot0.img")
-        }
     }
 
     pub fn ldd_path(&self) -> PathBuf {

--- a/src/common/stage2_config.rs
+++ b/src/common/stage2_config.rs
@@ -26,8 +26,11 @@ pub(crate) struct Stage2Config {
     pub umount_parts: Vec<UmountPart>,
     pub work_dir: PathBuf,
     pub image_path: PathBuf,
+    pub boot0_image_path: PathBuf,
+    pub boot0_image_dev: PathBuf,
     pub config_path: PathBuf,
     pub backup_path: Option<PathBuf>,
+    pub device_type: String,
     pub tty: PathBuf,
 }
 

--- a/src/common/stage2_config.rs
+++ b/src/common/stage2_config.rs
@@ -26,8 +26,6 @@ pub(crate) struct Stage2Config {
     pub umount_parts: Vec<UmountPart>,
     pub work_dir: PathBuf,
     pub image_path: PathBuf,
-    pub boot0_image_path: PathBuf,
-    pub boot0_image_dev: PathBuf,
     pub config_path: PathBuf,
     pub backup_path: Option<PathBuf>,
     pub device_type: String,

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -392,7 +392,7 @@ pub(crate) fn fuser<P: AsRef<Path>>(
         sleep(if let Some(wait_for_term) = wait_for_term {
             wait_for_term
         } else {
-            Duration::from_millis(500)
+            Duration::from_millis(3000)
         });
         let mut kill_count = 0;
         for pid in sent_signals {

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -1,5 +1,5 @@
 use libc::{
-    self, ino_t, mode_t, utsname, EACCES, EEXIST, ENOENT, ENXIO, EPERM, O_RDONLY, S_IFBLK, S_IFCHR,
+    self, ino_t, mode_t, utsname, EACCES, EEXIST, ENOENT, ENXIO, EPERM, EIO, O_RDONLY, S_IFBLK, S_IFCHR,
     S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
 
@@ -55,6 +55,7 @@ fn sys_error(message: &str) -> Error {
         ENOENT => ErrorKind::FileNotFound,
         ENXIO => ErrorKind::DeviceNotFound,
         EEXIST => ErrorKind::FileExists,
+        EIO=> ErrorKind::CmdIo,
         _ => ErrorKind::Upstream,
     };
     Error::with_all(error_kind, message, Box::new(io::Error::last_os_error()))

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{
         call,
         defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR},
-        get_mountpoint, path_append, whereis, Error, Result, ToError,
+        get_mountpoint, path_append, whereis, Error, Result, ToError, get_os_name,
     },
     stage2::{read_stage2_config, reboot},
     ErrorKind,
@@ -25,6 +25,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
+use std::path::{PathBuf};
 
 use crate::common::stage2_config::LogDevice;
 use libc::{
@@ -34,7 +35,7 @@ use libc::{
 
 const INITIAL_LOG_LEVEL: Level = Level::Trace;
 
-fn setup_log(log_dev: &LogDevice) -> Result<()> {
+fn setup_log(log_dev: &LogDevice, takeover_dir: &str) -> Result<()> {
     trace!(
         "setup_log entered with '{}', fs type: {}",
         log_dev.dev_name.display(),
@@ -54,7 +55,7 @@ fn setup_log(log_dev: &LogDevice) -> Result<()> {
             }
         }
 
-        let mountpoint = path_append(TAKEOVER_DIR, "/mnt/log");
+        let mountpoint = path_append(takeover_dir, "/mnt/log");
         create_dir_all(&mountpoint)
             .upstream_with_context("Failed to create log mount directory /mnt/log")?;
 
@@ -134,7 +135,7 @@ fn redirect_fd(file_name: &str, old_fd: c_int, mode: c_int) -> Result<()> {
     }
 }
 
-fn close_fds() -> Result<i32> {
+fn close_fds(takeover_dir: &str) -> Result<i32> {
     let mut pipe_fds: [c_int; 2] = [0; 2];
     let sys_rc = unsafe { pipe(pipe_fds.as_mut_ptr()) };
 
@@ -162,12 +163,12 @@ fn close_fds() -> Result<i32> {
     }
 
     redirect_fd(
-        &format!("{}/stdout.log", TAKEOVER_DIR),
+        &format!("{}/stdout.log", takeover_dir),
         STDOUT_FILENO,
         O_WRONLY | O_CREAT | O_TRUNC,
     )?;
     redirect_fd(
-        &format!("{}/stderr.log", TAKEOVER_DIR),
+        &format!("{}/stderr.log", takeover_dir),
         STDERR_FILENO,
         O_WRONLY | O_CREAT | O_TRUNC,
     )?;
@@ -216,15 +217,34 @@ pub fn init() -> ! {
 
     info!("Init check pid success!");
 
-    if let Err(why) = set_current_dir(TAKEOVER_DIR) {
+    let mut takeover_path = PathBuf::from("");
+    match get_os_name() {
+        Ok(name) => {
+            if name.starts_with("balenaOS") {
+                takeover_path.push("/mnt/boot");
+            }
+        }
+        Err(_) => {
+            error!("Can't determine operating system name");
+            reboot();
+        }
+    }
+    if TAKEOVER_DIR.starts_with("/") {
+        takeover_path.push(TAKEOVER_DIR[1..].to_string());
+    } else {
+        takeover_path.push(TAKEOVER_DIR);
+    }
+    let takeover_dir = takeover_path.to_str().unwrap_or(TAKEOVER_DIR);
+
+    if let Err(why) = set_current_dir(&takeover_path) {
         error!(
             "Failed to change to directory '{}', error: {:?}",
-            TAKEOVER_DIR, why
+            takeover_path.display(), why
         );
         reboot();
     }
 
-    let s2_config = match read_stage2_config(Some(TAKEOVER_DIR)) {
+    let s2_config = match read_stage2_config(Some(&takeover_path)) {
         Ok(s2_config) => s2_config,
         Err(why) => {
             error!("Failed to read stage2 configuration, error: {:?}", why);
@@ -243,7 +263,7 @@ pub fn init() -> ! {
         }
     }
 
-    let closed_fds = match close_fds() {
+    let closed_fds = match close_fds(takeover_dir) {
         Ok(fds) => fds,
         Err(_) => {
             error!("Failed close open files");
@@ -253,7 +273,7 @@ pub fn init() -> ! {
     info!("Stage 2 closed {} fd's", closed_fds);
 
     let ext_log = if let Some(log_dev) = s2_config.log_dev() {
-        match setup_log(log_dev) {
+        match setup_log(log_dev, takeover_dir) {
             Ok(_) => true,
             Err(why) => {
                 error!("Setup log failed, error: {:?}", why);

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,8 +1,6 @@
 use crate::{
     common::{
-        call,
-        defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR},
-        get_mountpoint, path_append, whereis, Error, Result, ToError, get_os_name,
+        call, defs::{BALENA_DATA_MP, BALENA_OS_NAME, MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR}, get_mountpoint, get_os_name, path_append, whereis, Error, Result, ToError
     },
     stage2::{read_stage2_config, reboot},
     ErrorKind,
@@ -220,8 +218,8 @@ pub fn init() -> ! {
     let mut takeover_path = PathBuf::from("");
     match get_os_name() {
         Ok(name) => {
-            if name.starts_with("balenaOS") {
-                takeover_path.push("/mnt/boot");
+            if name.starts_with(BALENA_OS_NAME) {
+                takeover_path.push(BALENA_DATA_MP);
             }
         }
         Err(_) => {

--- a/src/init.rs
+++ b/src/init.rs
@@ -107,7 +107,7 @@ fn redirect_fd(file_name: &str, old_fd: c_int, mode: c_int) -> Result<()> {
         .into_raw();
 
     let new_fd = unsafe { open(filename, mode) };
-    let _ = unsafe { CString::from_raw(filename) };
+
     if new_fd >= 0 {
         let res = unsafe { dup2(new_fd, old_fd) };
         if res >= 0 {

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -50,6 +50,7 @@ use crate::{
         block_device_info::BlockDevice, block_device_info::BlockDeviceInfo, exe_copy::ExeCopy,
         migrate_info::MigrateInfo, utils::mount_fs,
     },
+    stage1::defs::BOOT_BLOB_NAME_JETSON_XAVIER,
 };
 
 use crate::common::defs::{DD_CMD, EFIBOOTMGR_CMD, TAKEOVER_DIR};
@@ -70,7 +71,7 @@ fn prepare_configs<P1: AsRef<Path>>(
     mig_info.update_config()?;
 
     // *********************************************************
-    // write network_manager filess to tmpfs
+    // write network_manager files to tmpfs
     let mut nwmgr_cfgs: u64 = 0;
     let nwmgr_path = path_append(work_dir, SYSTEM_CONNECTIONS_DIR);
     create_dir_all(&nwmgr_path).upstream_with_context(&format!(
@@ -78,10 +79,29 @@ fn prepare_configs<P1: AsRef<Path>>(
         nwmgr_path.display()
     ))?;
 
+    /* If migrating from balenaOS, copy all files from the system-connections file in /mnt/boot
+     * TODO: Check if we should copy them from the boot partition, or from the NM root overlay directory
+     */
+    if mig_info.os_name().starts_with("balenaOS") {
+        debug!("migrating from balenaOS");
+        let  nwmgr_files = read_dir("/mnt/boot/system-connections/").unwrap();
+        for path in nwmgr_files {
+            mig_info.add_nwmgr_file(path.unwrap().path());
+        }
+    }
+
     for source_file in mig_info.nwmgr_files() {
         nwmgr_cfgs += 1;
-        let target_file = path_append(&nwmgr_path, &format!("balena-{:02}", nwmgr_cfgs));
-        copy(source_file, &target_file).upstream_with_context(&format!(
+        let target_file ;
+
+        /* If migrating from balenaOS, preserve file names for all entries in system-connections/ */
+        if !mig_info.os_name().starts_with("balenaOS") {
+            target_file = path_append(&nwmgr_path, &format!("balena-{:02}", nwmgr_cfgs));
+        } else {
+            let target_file_name = Path::new(source_file).file_name().unwrap().to_str().unwrap();
+            target_file = path_append(&nwmgr_path, target_file_name);
+        }
+        copy(&source_file, &target_file).upstream_with_context(&format!(
             "Failed to copy '{}' to '{}'",
             source_file.display(),
             target_file.display()
@@ -226,7 +246,9 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     let mut req_space: u64 = 0;
     let mut copy_commands = vec![DD_CMD];
-    if mig_info.is_x86() && !opts.no_efi_setup() && dir_exists(SYS_EFI_DIR)? {
+
+    /* If device is a Jetson Xavier, don't copy over efibootmgr because the old L4T does not use EFI */
+    if mig_info.is_x86() && !opts.no_efi_setup() && !mig_info.is_jetson_xavier() && dir_exists(SYS_EFI_DIR)? {
         copy_commands.push(EFIBOOTMGR_CMD)
     }
 
@@ -267,7 +289,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     // *********************************************************
     // make mountpoint for tmpfs
     let mut takeover_dir = PathBuf::from("");
-    if get_os_name()?.starts_with("balenaOS") {
+    if mig_info.os_name().starts_with("balenaOS") {
         // base directory for mountpoint must be writeable
         takeover_dir.push("/mnt/boot");
     }
@@ -318,7 +340,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     mig_info.set_to_dir(&takeover_dir);
 
-    info!("Using '{}' as takeover directory", takeover_dir.display());
+    info!("Using '{}' as takeover directory on '{}'", takeover_dir.display(), mig_info.os_name());
 
     mount_sys_filesystems(&takeover_dir, mig_info, opts)?;
 
@@ -335,6 +357,30 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     info!("Created directory '{}'", curr_path.display());
 
     commands.copy_files(&takeover_dir)?;
+
+    /* The Jetson AGX Xavier has a hardware defined partition, exposed as /dev/mmcblk0boot0,
+     * which contains various firmware specific to this device. We thus copy this image to the
+     * next stage, where it will be written right before the OS image is written with dd.
+     */
+    if mig_info.is_jetson_xavier() {
+        info!("Device is a Jetson Xavier AGX. Will copy boot0 image.");
+        let src_path = mig_info.boot0_image_path().canonicalize().upstream_with_context(&format!(
+            "Failed to canonicalize boot0 source path: '{}'",
+            mig_info.boot0_image_path().display()
+        ))?;
+
+        debug!("Will copy boot0 image from '{}'", src_path.display());
+        let boot0_copy_path = path_append(&takeover_dir, PathBuf::from(BOOT_BLOB_NAME_JETSON_XAVIER));
+
+        let res = copy(src_path, &boot0_copy_path);
+        match res {
+            Ok(_val) => (),
+            Err(err) => {
+                warn!("Failed to copy boot0_img {}", err);
+            }
+        }
+        debug!("Copied boot0 image to '{}'", boot0_copy_path.display());
+    }
 
     prepare_configs(opts.work_dir(), mig_info)?;
 
@@ -433,8 +479,15 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
                 opts.work_dir().display()
             ))?,
         image_path: mig_info.image_path().to_path_buf(),
+        boot0_image_path : PathBuf::from(BOOT_BLOB_NAME_JETSON_XAVIER), /* destination file name */
+        boot0_image_dev : mig_info.boot0_image_dev().to_path_buf(), /* hardware boot partition or QSPI path */
         config_path: mig_info.balena_cfg().get_path().to_path_buf(),
-        backup_path: mig_info.backup().map(|backup_path| backup_path.to_owned()),
+        backup_path: if let Some(backup_path) = mig_info.backup() {
+            Some(backup_path.to_owned())
+        } else {
+            None
+        },
+        device_type: mig_info.get_device_type_name().to_string(),
         tty: read_link("/proc/self/fd/1")
             .upstream_with_context("Failed to read tty from '/proc/self/fd/1'")?,
     };

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -284,7 +284,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
         copy_commands.push(MTD_DEBUG_CMD)
     }
 
-    let commands = match ExeCopy::new(copy_commands) {
+    let commands = match ExeCopy::new(copy_commands, opts) {
         Ok(commands) => {
             let cmd_space = commands.get_req_space();
             debug!(

--- a/src/stage1/block_device_info.rs
+++ b/src/stage1/block_device_info.rs
@@ -112,8 +112,15 @@ pub(crate) struct BlockDeviceInfo {
 }
 
 impl BlockDeviceInfo {
+    /// Create a BlockDeviceInfo based on the storage device used for the root directory.
     pub fn new() -> Result<BlockDeviceInfo> {
-        let stat_res = stat("/").upstream_with_context("Failed to stat root")?;
+        BlockDeviceInfo::new_for_dir("/")
+    }
+
+    /// Create a BlockDeviceInfo based on the storage device used for the provided
+    /// directory.
+    pub fn new_for_dir(dir: &str) -> Result<BlockDeviceInfo> {
+        let stat_res = stat(dir).upstream_with_context(&format!("Failed to stat for {}", dir))?;
         let root_number = DeviceNum::new(stat_res.st_dev);
         let mounts = Mount::from_mtab()?;
 

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Display};
 
 pub const DEV_TYPE_INTEL_NUC: &str = "intel-nuc";
-pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext";
+pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext";   // MBR
+pub const DEV_TYPE_GEN_AMD64: &str = "generic-amd64";        // GPT
 pub const DEV_TYPE_RPI3: &str = "raspberrypi3";
 pub const DEV_TYPE_RPI2: &str = "raspberry-pi2";
 pub const DEV_TYPE_RPI1: &str = "raspberry-pi";

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -11,12 +11,15 @@ pub const DEV_TYPE_BBG: &str = "beaglebone-green";
 pub const DEV_TYPE_BBB: &str = "beaglebone-black";
 pub const DEV_TYPE_BBXM: &str = "beagleboard-xm";
 pub const DEV_TYPE_JETSON_XAVIER: &str = "jetson-xavier";
+pub const DEV_TYPE_JETSON_XAVIER_NX: &str = "jetson-xavier-nx-devkit";
 
 /* Hardware defined boot partition for Jetson AGX Xavier */
 pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER_NX: &str = "/dev/mtd0";
 
 /* Stage 2 destination file name for the boot blob */
 pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
+pub const BOOT_BLOB_NAME_JETSON_XAVIER_NX: &str = "boot0_mtdblock0.img";
 
 pub const MAX_CONFIG_JSON: usize = 2048;
 pub const GZIP_MAGIC_COOKIE: u16 = 0x1f8b;
@@ -31,7 +34,9 @@ pub(crate) enum DeviceType {
     RaspberryPi2,
     RaspberryPi3,
     RaspberryPi4,
-    JetsonXavier
+    JetsonXavier,
+    JetsonXavierNX,
+
 }
 
 impl Display for DeviceType {
@@ -48,7 +53,8 @@ impl Display for DeviceType {
                 Self::RaspberryPi2 => "Raspberry Pi 2",
                 Self::RaspberryPi3 => "Raspberry Pi 3",
                 Self::RaspberryPi4 => "Raspberry Pi 4",
-                Self::JetsonXavier => "Jetson Xavier",
+                Self::JetsonXavier => "Jetson Xavier AGX",
+                Self::JetsonXavierNX => "Jetson Xavier NX",
             }
         )
     }

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -12,6 +12,7 @@ pub const DEV_TYPE_BBB: &str = "beaglebone-black";
 pub const DEV_TYPE_BBXM: &str = "beagleboard-xm";
 pub const DEV_TYPE_JETSON_XAVIER: &str = "jetson-xavier";
 pub const DEV_TYPE_JETSON_XAVIER_NX: &str = "jetson-xavier-nx-devkit";
+pub const DEV_TYPE_JETSON_XAVIER_NX_EMMC: &str = "jetson-xavier-nx-devkit-emmc";
 
 /* Hardware defined boot partition for Jetson AGX Xavier */
 pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -10,11 +10,18 @@ pub const DEV_TYPE_RPI4_64: &str = "raspberrypi4-64";
 pub const DEV_TYPE_BBG: &str = "beaglebone-green";
 pub const DEV_TYPE_BBB: &str = "beaglebone-black";
 pub const DEV_TYPE_BBXM: &str = "beagleboard-xm";
+pub const DEV_TYPE_JETSON_XAVIER: &str = "jetson-xavier";
+
+/* Hardware defined boot partition for Jetson AGX Xavier */
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
+
+/* Stage 2 destination file name for the boot blob */
+pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
 
 pub const MAX_CONFIG_JSON: usize = 2048;
 pub const GZIP_MAGIC_COOKIE: u16 = 0x1f8b;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum DeviceType {
     BeagleboneGreen,
     BeagleboneBlack,
@@ -24,6 +31,7 @@ pub(crate) enum DeviceType {
     RaspberryPi2,
     RaspberryPi3,
     RaspberryPi4,
+    JetsonXavier
 }
 
 impl Display for DeviceType {
@@ -40,6 +48,7 @@ impl Display for DeviceType {
                 Self::RaspberryPi2 => "Raspberry Pi 2",
                 Self::RaspberryPi3 => "Raspberry Pi 3",
                 Self::RaspberryPi4 => "Raspberry Pi 4",
+                Self::JetsonXavier => "Jetson Xavier",
             }
         )
     }

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -14,14 +14,6 @@ pub const DEV_TYPE_JETSON_XAVIER: &str = "jetson-xavier";
 pub const DEV_TYPE_JETSON_XAVIER_NX: &str = "jetson-xavier-nx-devkit";
 pub const DEV_TYPE_JETSON_XAVIER_NX_EMMC: &str = "jetson-xavier-nx-devkit-emmc";
 
-/* Hardware defined boot partition for Jetson AGX Xavier */
-pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
-pub const BOOT_BLOB_PARTITION_JETSON_XAVIER_NX: &str = "/dev/mtd0";
-
-/* Stage 2 destination file name for the boot blob */
-pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
-pub const BOOT_BLOB_NAME_JETSON_XAVIER_NX: &str = "boot0_mtdblock0.img";
-
 pub const MAX_CONFIG_JSON: usize = 2048;
 pub const GZIP_MAGIC_COOKIE: u16 = 0x1f8b;
 

--- a/src/stage1/device_impl.rs
+++ b/src/stage1/device_impl.rs
@@ -11,6 +11,7 @@ use crate::{
 mod beaglebone;
 mod intel_nuc;
 mod raspberrypi;
+mod jetson_xavier;
 
 const DEVICE_TREE_MODEL: &str = "/proc/device-tree/model";
 
@@ -60,6 +61,10 @@ pub(crate) fn get_device(opts: &Options) -> Result<Box<dyn Device>> {
             }
 
             if let Some(device) = beaglebone::is_bb(opts, &dev_tree_model)? {
+                return Ok(device);
+            }
+
+            if let Some(device) = jetson_xavier::is_jetson_xavier(opts, &dev_tree_model)? {
                 return Ok(device);
             }
 

--- a/src/stage1/device_impl/intel_nuc.rs
+++ b/src/stage1/device_impl/intel_nuc.rs
@@ -5,13 +5,13 @@ use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC},
+        defs::{DeviceType, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_AMD64},
         device::Device,
         utils::is_secure_boot,
     },
 };
 
-const X86_SLUGS: [&str; 2] = [DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_X86_64];
+const X86_SLUGS: [&str; 3] = [DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_X86_64, DEV_TYPE_GEN_AMD64];
 
 pub(crate) struct IntelNuc;
 
@@ -28,6 +28,7 @@ impl IntelNuc {
             "Ubuntu 14.04.5 LTS",
             "Ubuntu 14.04.6 LTS",
             "Manjaro Linux",
+            "balenaOS 4.0.23",
         ];
 
         if opts.migrate() {

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -5,7 +5,7 @@ use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX},
+        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER_NX_EMMC},
         device::Device,
     },
 };
@@ -30,7 +30,7 @@ pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Opt
 }
 
 const XAVIER_AGX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER];
-const XAVIER_NX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER_NX];
+const XAVIER_NX_SLUGS: [&str; 2] = [DEV_TYPE_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER_NX_EMMC];
 
 
 pub(crate) struct JetsonXavier;

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -5,7 +5,7 @@ use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER},
+        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX},
         device::Device,
     },
 };
@@ -20,13 +20,18 @@ pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Opt
         // TODO: found this device model on AGX Xavier running L4T 35.4.1
         debug!("match found for Xavier AGX");
         Ok(Some(Box::new(JetsonXavier::from_config(opts)?)))
-    } else {
-        debug!("no match for Jetson-AGX on: <{}>", model_string);
+    } else if model_string.eq("NVIDIA Jetson Xavier NX Developer Kit") {
+        debug!("match found for Xavier NX Devkit");
+        Ok(Some(Box::new(JetsonXavierNX::from_config(opts)?)))
+    } else  {
+        debug!("no match for Jetson-AGX or NVIDIA Jetson Xavier NX Developer Kit on: <{}>", model_string);
         Ok(None)
     }
 }
 
 const XAVIER_AGX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER];
+const XAVIER_NX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER_NX];
+
 
 pub(crate) struct JetsonXavier;
 
@@ -58,5 +63,38 @@ impl<'a> Device for JetsonXavier {
     }
     fn get_device_type(&self) -> DeviceType {
         DeviceType::JetsonXavier
+    }
+}
+
+pub(crate) struct JetsonXavierNX;
+
+impl JetsonXavierNX {
+    pub fn from_config(opts: &Options) -> Result<JetsonXavierNX> {
+        const SUPPORTED_OSSES: &[&str] = &[
+                   "balenaOS 5.1.20",
+                   "balenaOS 3.1.3+rev1",
+        ];
+
+        if opts.migrate() {
+            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+                return Err(Error::displayed());
+            }
+
+            // **********************************************************************
+            // ** Xavier AGX specific initialisation/checks
+            // **********************************************************************
+
+
+        }
+        Ok(JetsonXavierNX)
+    }
+}
+
+impl<'a> Device for JetsonXavierNX {
+    fn supports_device_type(&self, dev_type: &str) -> bool {
+        XAVIER_NX_SLUGS.contains(&dev_type)
+    }
+    fn get_device_type(&self) -> DeviceType {
+        DeviceType::JetsonXavierNX
     }
 }

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -1,0 +1,62 @@
+use log::{debug, trace};
+
+use crate::stage1::device_impl::check_os;
+use crate::{
+    common::{Error, Options, Result},
+    // linux_common::is_secure_boot,
+    stage1::{
+        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER},
+        device::Device,
+    },
+};
+
+pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Option<Box<dyn Device>>> {
+    trace!(
+        "JetsonXavier::is_jetson_xavier: entered with model string: '{}'",
+        model_string
+    );
+
+    if model_string.eq("Jetson-AGX") {
+        // TODO: found this device model on AGX Xavier running L4T 35.4.1
+        debug!("match found for Xavier AGX");
+        Ok(Some(Box::new(JetsonXavier::from_config(opts)?)))
+    } else {
+        debug!("no match for Jetson-AGX on: <{}>", model_string);
+        Ok(None)
+    }
+}
+
+const XAVIER_AGX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER];
+
+pub(crate) struct JetsonXavier;
+
+impl JetsonXavier {
+    pub fn from_config(opts: &Options) -> Result<JetsonXavier> {
+        const SUPPORTED_OSSES: &[&str] = &[
+                   "balenaOS 5.1.20",
+                   "balenaOS 3.1.3+rev1",
+        ];
+
+        if opts.migrate() {
+            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+                return Err(Error::displayed());
+            }
+
+            // **********************************************************************
+            // ** Xavier AGX specific initialisation/checks
+            // **********************************************************************
+
+
+        }
+        Ok(JetsonXavier)
+    }
+}
+
+impl<'a> Device for JetsonXavier {
+    fn supports_device_type(&self, dev_type: &str) -> bool {
+        XAVIER_AGX_SLUGS.contains(&dev_type)
+    }
+    fn get_device_type(&self) -> DeviceType {
+        DeviceType::JetsonXavier
+    }
+}

--- a/src/stage1/image_retrieval.rs
+++ b/src/stage1/image_retrieval.rs
@@ -20,7 +20,7 @@ use crate::{
         api_calls::{get_os_image, get_os_versions, Versions},
         defs::{
             DEV_TYPE_BBB, DEV_TYPE_BBG, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_RPI1,
-            DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64,
+            DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64, DEV_TYPE_JETSON_XAVIER,
         },
         migrate_info::balena_cfg_json::BalenaCfgJson,
     },
@@ -30,13 +30,14 @@ use crate::{
 use flate2::{Compression, GzBuilder};
 use nix::mount::{mount, umount, MsFlags};
 
-const FLASHER_DEVICES: [&str; 4] = [
+pub const FLASHER_DEVICES: [&str; 5] = [
     DEV_TYPE_INTEL_NUC,
     DEV_TYPE_GEN_X86_64,
     DEV_TYPE_BBG,
     DEV_TYPE_BBB,
+    DEV_TYPE_JETSON_XAVIER,
 ];
-const SUPPORTED_DEVICES: [&str; 8] = [
+const SUPPORTED_DEVICES: [&str; 9] = [
     DEV_TYPE_RPI3,
     DEV_TYPE_RPI2,
     DEV_TYPE_RPI4_64,
@@ -45,12 +46,14 @@ const SUPPORTED_DEVICES: [&str; 8] = [
     DEV_TYPE_GEN_X86_64,
     DEV_TYPE_BBG,
     DEV_TYPE_BBB,
+    DEV_TYPE_JETSON_XAVIER,
 ];
 
 const IMG_NAME_GEN_X86_64: &str = "resin-image-genericx86-64-ext.resinos-img";
 const IMG_NAME_INTEL_NUC: &str = "resin-image-genericx86-64.resinos-img";
 const IMG_NAME_BBG: &str = "resin-image-beaglebone-green.resinos-img";
 const IMG_NAME_BBB: &str = "resin-image-beaglebone-black.resinos-img";
+const IMG_NAME_JETSON_XAVIER: &str = "balena-image-jetson-xavier.balenaos-img";
 
 fn parse_versions(versions: &Versions) -> Vec<Version> {
     let mut sem_vers: Vec<Version> = versions
@@ -166,7 +169,7 @@ fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
     }
 }
 
-fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
+pub(crate) fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
     stream: Box<dyn Read>,
     image_file_name: P1,
     device_type: &str,
@@ -226,6 +229,7 @@ fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
             }
             DEV_TYPE_BBB => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBB),
             DEV_TYPE_BBG => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBG),
+            DEV_TYPE_JETSON_XAVIER => path_append(path_append(&mount_path, "opt"), IMG_NAME_JETSON_XAVIER),
             _ => {
                 return Err(Error::with_context(
                     ErrorKind::InvParam,

--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -11,7 +11,7 @@ use crate::{
     stage1::{
         backup::config::backup_cfg_from_file,
         backup::{create, create_ext},
-        defs::{DEV_TYPE_GEN_X86_64, GZIP_MAGIC_COOKIE, MAX_CONFIG_JSON, BOOT_BLOB_PARTITION_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER},
+        defs::{DEV_TYPE_GEN_X86_64, GZIP_MAGIC_COOKIE, MAX_CONFIG_JSON, BOOT_BLOB_PARTITION_JETSON_XAVIER, BOOT_BLOB_PARTITION_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX},
         device::Device,
         device_impl::get_device,
         image_retrieval::{download_image, FLASHER_DEVICES},
@@ -137,7 +137,7 @@ impl MigrateInfo {
          */
         let mut boot0_image_path = PathBuf::new();
         let mut boot0_image_dev = PathBuf::new();
-        if device.supports_device_type(DEV_TYPE_JETSON_XAVIER) {
+        if device.supports_device_type(DEV_TYPE_JETSON_XAVIER) || device.supports_device_type(DEV_TYPE_JETSON_XAVIER_NX){
              boot0_image_path = opts
             .boot0_image()
             .canonicalize()
@@ -150,7 +150,11 @@ impl MigrateInfo {
                 info!("boot0 image found!");
             }
 
-            boot0_image_dev = PathBuf::from(BOOT_BLOB_PARTITION_JETSON_XAVIER);
+            if device.supports_device_type(DEV_TYPE_JETSON_XAVIER) {
+                boot0_image_dev = PathBuf::from(BOOT_BLOB_PARTITION_JETSON_XAVIER);
+            } else if device.supports_device_type(DEV_TYPE_JETSON_XAVIER_NX) {
+                boot0_image_dev = PathBuf::from(BOOT_BLOB_PARTITION_JETSON_XAVIER_NX);
+            }
         }
 
         /* TODO: Check if we will convert the Jetson AGX, Jetson Xavier NX eMMC and NX SD to flasher types */
@@ -253,6 +257,10 @@ impl MigrateInfo {
 
     pub fn is_jetson_xavier(&self) -> bool {
         self.device.supports_device_type(DEV_TYPE_JETSON_XAVIER)
+    }
+
+    pub fn is_jetson_xavier_nx(&self) -> bool {
+        self.device.supports_device_type(DEV_TYPE_JETSON_XAVIER_NX)
     }
 
     pub fn backup(&self) -> Option<&Path> {

--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -45,6 +45,7 @@ pub(crate) struct MigrateInfo {
     work_dir: PathBuf,
     wifis: Vec<WifiConfig>,
     nwmgr_files: Vec<PathBuf>,
+    system_proxy_files: Vec<PathBuf>,
     backup: Option<PathBuf>,
 }
 
@@ -173,6 +174,7 @@ impl MigrateInfo {
         };
 
         let nwmgr_files = Vec::from(opts.nwmgr_cfg());
+        let system_proxy_files = Vec::new();
 
         if nwmgr_files.is_empty() && wifis.is_empty() {
             if opts.no_nwmgr_check() {
@@ -226,6 +228,7 @@ impl MigrateInfo {
             work_dir,
             wifis,
             nwmgr_files,
+            system_proxy_files,
             backup,
         })
     }
@@ -302,9 +305,18 @@ impl MigrateInfo {
         &self.nwmgr_files
     }
 
+    pub fn system_proxy_files(&self) -> &Vec<PathBuf> {
+        &self.system_proxy_files
+    }
+
     pub fn add_nwmgr_file<P: AsRef<Path>>(&mut self, nwmgr_file_path: P) {
         self.nwmgr_files.push(nwmgr_file_path.as_ref().to_path_buf());
         debug!("Adding network connection file to copy list: {}", nwmgr_file_path.as_ref().to_path_buf().display());
+    }
+
+    pub fn add_system_proxy_file<P: AsRef<Path>>(&mut self, system_proxy_file_path: P) {
+        self.system_proxy_files.push(system_proxy_file_path.as_ref().to_path_buf());
+        debug!("Adding system proxy configuration file to copy list: {}", system_proxy_file_path.as_ref().to_path_buf().display());
     }
 
     pub fn wifis(&self) -> &Vec<WifiConfig> {

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -30,7 +30,7 @@ use crate::common::{
         OLD_ROOT_MP, STAGE2_CONFIG_NAME, SYSTEM_CONNECTIONS_DIR, SYS_EFI_DIR,
     },
     dir_exists,
-    disk_util::{Disk, PartInfo, PartitionIterator, DEF_BLOCK_SIZE},
+    disk_util::{Disk, LabelType, PartInfo, PartitionIterator, DEF_BLOCK_SIZE},
     error::{Error, ErrorKind, Result, ToError},
     file_exists, format_size_with_unit, get_mem_info,
     loop_device::LoopDevice,
@@ -520,30 +520,87 @@ fn transfer_boot_files<P: AsRef<Path>>(dev_root: P) -> Result<()> {
 
 fn get_partition_infos(device: &Path) -> Result<(PartInfo, PartInfo)> {
     let mut disk = Disk::from_drive_file(device, None)?;
-    let part_iterator = PartitionIterator::new(&mut disk)?;
+
     let mut boot_part: Option<PartInfo> = None;
     let mut data_part: Option<PartInfo> = None;
 
-    for partition in part_iterator {
-        debug!(
-            "partition: {}, start: {}, sectors: {}",
-            partition.index, partition.start_lba, partition.num_sectors
-        );
+    // GPT provides a 'protective MBR' at LBA 0 to identify itself in a backward
+    // compatible way. So, read the GPT header if so.
+    let is_gpt = disk.get_label()? == LabelType::GPT;
 
-        match partition.index {
-            1 => {
-                boot_part = Some(partition);
+    if !is_gpt {
+        let part_iterator = PartitionIterator::new(&mut disk)?;
+        for partition in part_iterator {
+            debug!(
+                "partition: {}, start: {}, sectors: {}",
+                partition.index, partition.start_lba, partition.num_sectors
+            );
+
+            match partition.index {
+                1 => {
+                    boot_part = Some(partition);
+                }
+                2..=5 => debug!("Skipping partition {}", partition.index),
+                6 => {
+                    data_part = Some(partition);
+                    break;
+                }
+                _ => {
+                    return Err(Error::with_context(
+                        ErrorKind::InvParam,
+                        &format!("Invalid partition index encountered: {}", partition.index),
+                    ));
+                }
             }
-            2..=5 => debug!("Skipping partition {}", partition.index),
-            6 => {
-                data_part = Some(partition);
-                break;
-            }
-            _ => {
+        }
+    } else {
+        // Use the iterator built into gptman and populate the PartInfo structs
+        // for the boot and data partitions as best we can.
+        let gpt = match disk.read_gpt() {
+            Ok(gpt_res) => gpt_res,
+            Err(e) => {
                 return Err(Error::with_context(
-                    ErrorKind::InvParam,
-                    &format!("Invalid partition index encountered: {}", partition.index),
-                ));
+                    ErrorKind::InvState,
+                    &format!("Failed to read GPT header, error: {} ", e)));
+            }
+        };
+        for (i, p) in gpt.iter() {
+            if p.is_used() {
+                debug!("Partition #{}: type = {:?}, size = {} bytes, starting lba = {}, name = {}",
+                    i,
+                    p.partition_type_guid,
+                    p.size().unwrap() * gpt.sector_size,
+                    p.starting_lba,
+                    p.partition_name.as_str());
+                match i {
+                    1 => {
+                        boot_part = Some(PartInfo {
+                            index: i as usize,
+                            ptype: 0x83,  // MBR Linux byte; really this is the EFI system
+                                          // partition, but MBR doesn't define this type.
+                            status: 0,    // Not clear what this should be
+                            start_lba: p.starting_lba,
+                            num_sectors: p.size().unwrap()
+                        })
+                    }
+                    2..=4 => debug!("Skipping partition {}", i),
+                    5 => {
+                        data_part = Some(PartInfo {
+                            index: i as usize,
+                            ptype: 0x83,  // MBR Linux byte
+                            status: 0,    // not clear what this should be
+                            start_lba: p.starting_lba,
+                            num_sectors: p.size().unwrap()
+                        });
+                        break;
+                    }
+                    _ => {
+                        return Err(Error::with_context(
+                            ErrorKind::InvParam,
+                            &format!("Invalid partition index encountered: {}", i),
+                        ));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Jetson Xavier AGX: These test changes have successfully migrated:

- a Jetson Xavier AGX running balenaOS v3.1.3 (L4T 32.7.3) production image to a
    v5.1.20 (L4T 35.4.1) local Yocto build (non-flasher)
- a Jetson Xavier NX eMMC Devkit running the latest balenaOS image from balena-cloud to a v5.1.46 (L4T 35.4.1) local Yocto build (non-flasher)
- a Jetson Xavier NX SD-CARD Devkit running the latest balenaOS image from balena-cloud  to a v5.1.46 (L4T 35.4.1) local Yocto build (non-flasher)
- a Jetson Xavier NX eMMC in Seeed J2021 (devkit compatible) running the latest balenaOS image from balena-cloud to a v5.1.46 (L4T 35.4.1) local Yocto build (non-flasher)
- All the above, from the latest Yocto L4T local Yocto builds, to the same build
    
    
What this does:

<strike>- Writes boot blob passed as argument to the hw defined boot partition</strike>
- Extracts the boot blob from the new balenaOS image, after it has been written to the eMMC, and writes it to the hw defined partition in the case of the Xavier AGX, or the QSPI in the case of the Xavier NX SD & NX eMMC.
- Copies the existing config.json when migrating from balenaOS
- Copies the existing system connection files from /mnt/boot when migrating from balenaOS
- Copies the existing system proxy files from /mnt/boot when migrating from balenaOS
- Allows passing the path to `ldd` as argument. The ldd script can be placed near the takeover binary
       
Issues:

<strike>- Cannot extract balena-image from balena-image flasher (may not be necessary)</strike>
<strike>- Uses boot0.img passed by cmdline, could not extract boot0.img from the non-flasher image (yet)</strike>
<strike>- Old root filesystem needs to include ldd</strike>
- May break other devices
- Needs careful review and likel some parts re-written
 
Line used for testing:
    
PATH="${PATH}:/mnt/data/migrate/bin" ./takeover -i balena-image-jetson-xavier-20240209144210.rootfs.balenaos-img.gz --no-nwmgr-check --log-file /mnt/data/migrate/stage1.log --log-level trace -l /dev/sda1
        --s2-log-level --no-os-check --no-wifis
    
where:
    
- balena-image-jetson-xavier-20240209144210.rootfs.balenaos-img.gz is a local build of a non flasher image running on L4T 35.4.1
- sda1 is a USB drive plugged into the device, for preserving stage2 logs
- no-wifis ensures no wifi connections are created, and the ones existing in /mnt/boot/ are transferred
