### PR TITLE
Update `get_os_version` to use /v6/release

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo ./takeover -c config.json
 ``` 
 on the command line.
  
-The above command will download the latest production image for your platform and migrate the device to balena. 
+The above command will download the latest image for your platform and migrate the device to balena. 
 
 Several options are available to cover special situations: 
 
@@ -78,15 +78,15 @@ The *takeover* command allows you to specify a balena-os version for download or
 
 #### Downloading an image
 
-By default *takeover* will download the latest production image for the platform specified in your config.json. 
-If you need a development image or a version different from the latest you can use the ```--version``` option to specify 
+By default *takeover* will download the latest image for the platform specified in your config.json. 
+If you need a version different from the latest you can use the ```--version``` option to specify 
 a version. 
-The ```--version``` option accepts either a full image name (eg. ```--version 2.50.1+rev1.dev```) or parsing 
+The ```--version``` option accepts either a full image name (eg. ```--version 5.1.20+rev1```) or parsing 
 of ~x.y.z and ^x.y.z requirements as defined at [semver](https://www.npmjs.com/package/semver)
- (eg. ```--version ~2.48```).
+ (eg. ```--version ~5.1```).
  Example: 
  ```shell script
-./sudo takeover -c config.json --version 2.50.1+rev1.dev
+./sudo takeover -c config.json --version 5.1.20+rev1
 ```
    
 When downloading images,  certain platforms (mainly intel-nuc, Generic-x86_64, beaglebone) require unpacking the image and 

--- a/src/stage1/image_retrieval.rs
+++ b/src/stage1/image_retrieval.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use log::{debug, error, info, warn, Level};
 
-use semver::{Identifier, Version, VersionReq};
+use semver::{Version, VersionReq};
 
 use crate::{
     common::{
@@ -54,7 +54,6 @@ const IMG_NAME_BBB: &str = "resin-image-beaglebone-black.resinos-img";
 
 fn parse_versions(versions: &Versions) -> Vec<Version> {
     let mut sem_vers: Vec<Version> = versions
-        .versions
         .iter()
         .map(|ver_str| Version::parse(ver_str))
         .filter_map(|ver_res| match ver_res {
@@ -72,25 +71,13 @@ fn parse_versions(versions: &Versions) -> Vec<Version> {
 
 fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
     match ver_str {
-        "latest" => {
-            info!("Selected latest version ({}) for download", versions.latest);
-            Ok(
-                Version::parse(&versions.latest).upstream_with_context(&format!(
-                    "Failed to parse version from '{}'",
-                    versions.latest
-                ))?,
-            )
-        }
         "default" => {
             let mut found: Option<Version> = None;
             for cmp_ver in parse_versions(versions) {
                 debug!("Looking at version {}", cmp_ver);
                 if cmp_ver.is_prerelease() {
                     continue;
-                } else if cmp_ver
-                    .build
-                    .contains(&Identifier::AlphaNumeric("prod".to_string()))
-                {
+                } else {
                     found = Some(cmp_ver);
                     break;
                 }
@@ -114,12 +101,7 @@ fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
                 ))?;
                 let mut found: Option<Version> = None;
                 for cmp_ver in parse_versions(versions) {
-                    if ver_req.matches(&cmp_ver)
-                        && !cmp_ver.is_prerelease()
-                        && cmp_ver
-                            .build
-                            .contains(&Identifier::AlphaNumeric("prod".to_string()))
-                    {
+                    if ver_req.matches(&cmp_ver) && !cmp_ver.is_prerelease() {
                         found = Some(cmp_ver);
                         break;
                     }
@@ -143,10 +125,7 @@ fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
                 for cmp_ver in parse_versions(versions) {
                     if ver_req == cmp_ver
                         && !cmp_ver.is_prerelease()
-                        && (cmp_ver.build == ver_req.build
-                            || cmp_ver
-                                .build
-                                .contains(&Identifier::AlphaNumeric("prod".to_string())))
+                        && (cmp_ver.build == ver_req.build)
                     {
                         found = Some(cmp_ver);
                         break;
@@ -163,6 +142,81 @@ fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const VERSIONS: [&str; 6] = [
+        "5.1.20+rev1",
+        "3.2.25",
+        "3.3.0",
+        "4.0.26+rev",
+        "5.0.1+rev1",
+        "0.0.0+rev60",
+    ];
+    use mod_logger::Logger;
+
+    #[test]
+    fn returns_latest_version_by_default() {
+        Logger::set_default_level(Level::Trace);
+
+        let selection = "default";
+        debug!("Selection is {}", selection);
+
+        let versions: Versions = VERSIONS.iter().map(|&s| s.to_string()).collect();
+
+        let result = determine_version(selection, &versions);
+        assert_eq!(
+            result.unwrap(),
+            Version::parse("5.1.20+rev1").expect("Could not parse version")
+        );
+    }
+
+    #[test]
+    fn returns_specific_version() {
+        Logger::set_default_level(Level::Trace);
+        let selection = "4.0.26+rev";
+        debug!("Selection is {}", selection);
+
+        let versions: Versions = VERSIONS.iter().map(|&s| s.to_string()).collect();
+
+        let result = determine_version(selection, &versions);
+        assert_eq!(
+            result.unwrap(),
+            Version::parse("4.0.26+rev").expect("Could not parse version")
+        );
+    }
+
+    #[test]
+    fn returns_compatible_version() {
+        Logger::set_default_level(Level::Trace);
+        let selection = "^3.2";
+        debug!("Selection is {}", selection);
+
+        let versions: Versions = VERSIONS.iter().map(|&s| s.to_string()).collect();
+
+        let result = determine_version(selection, &versions);
+        assert_eq!(
+            result.unwrap(),
+            Version::parse("3.3.0").expect("Could not parse version")
+        );
+    }
+
+    #[test]
+    fn returns_closest_version() {
+        Logger::set_default_level(Level::Trace);
+        let selection = "~3.2.8";
+        debug!("Selection is {}", selection);
+
+        let versions: Versions = VERSIONS.iter().map(|&s| s.to_string()).collect();
+
+        let result = determine_version(selection, &versions);
+        assert_eq!(
+            result.unwrap(),
+            Version::parse("3.2.25").expect("Could not parse version")
+        );
     }
 }
 


### PR DESCRIPTION
- /device-types/v1/ has been deprecated per issue https://github.com/balena-os/takeover/issues/18
- currently using percent-encoded url and replacing device-type in the url
- /v6/release returns a different response `JSON` compared to /device-types/v1/
and does not contain the `latest` field.
- replaced struct `Versions` with a type alias to `Vec<String>`
- modified `determine_versions` to handle new data structure and [unified images](https://blog.balena.io/unified-balenaos-releases-now-available/)
- added unit tests for `determine_versions`
- modified README to remove reference to `dev` and `prod` images