### PR TITLE
Make and use copy of `telinit` if symliked to `init`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +453,15 @@ name = "hermit-abi"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -1223,6 +1238,7 @@ dependencies = [
  "serde_yaml",
  "tar",
  "url",
+ "which",
 ]
 
 [[package]]
@@ -1473,6 +1489,19 @@ checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,11 +69,15 @@ version = "0.1"
 [dependencies.tar]
 version = "0.4"
 
+[dependencies.which]
+version = "6.0.0"
+
+[dependencies.openssl]
+version = "0.10.63"
+features = ["vendored"]
+
 [features]
 raspberrypi3 = []
 raspberrypi4-64 = []
 intel-nuc = []
 
-[dependencies.openssl]
-version = "0.10.63"
-features = ["vendored"]


### PR DESCRIPTION
At the end of stage1, we bind-mount `takeover` on top of `init`, and
then call `telinit u`. Unfortunately, in some distributions (like
Devuan) `telinit` is a symlink to `init`. In this case, we lose access
to `telinit`, because the symlink now points to what is effectively
`takeover`.

With this commit, we check if `telinit` is a symlink to `init`, and if
so, we make a safe copy of `telinit` so that we can call it after the
bind-mounting takes place.

### Testing

Tried simple migrations from

* Devuan ascii 2.0.0
* RaspiOS 2023-12-11 arm64
* RaspiOS 2023-12-11 armhf

to a fleet of device type `raspberrypi3-64`, on a Raspberry Pi 3 Model B+.

Checked the logs to confirm that the safety copy was made only for Devuan.

All migrations succeeded.
