### PR TITLE
Typo fixes by external contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ You can also specify your own NetworkManager configuration file using the ```--n
 
 If no network configurations are found *takeover* will print an error message and abort to keep you from accidentally 
 migrating a configuration that will not be able to come online. This check can be overridden by specifying the 
-```--np-nwmgr-check``` option. 
-   
+```--no-nwmgr-check``` option.
+
 By default *takeover* will migrate the devices hostname. This can be disabled using the ```--no-keep-name``` option. 
 
 ### Logging

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ of ~x.y.z and ^x.y.z requirements as defined at [semver](https://www.npmjs.com/p
  (eg. ```--version ~5.1```).
  Example: 
  ```shell script
-./sudo takeover -c config.json --version 5.1.20+rev1
+sudo ./takeover -c config.json --version 5.1.20+rev1
 ```
    
 When downloading images,  certain platforms (mainly intel-nuc, Generic-x86_64, beaglebone) require unpacking the image and 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -1098,7 +1098,7 @@ pub fn stage2(opts: &Options) -> ! {
     if let Err(why) = raw_mount_balena(&s2_config.flash_dev) {
         error!("Failed to transfer files to balena OS, error: {:?}", why);
     } else {
-        info!("Migration succeded successfully");
+        info!("Migration completed successfully");
     }
 
     sync();


### PR DESCRIPTION
I just cherry-picked the commits from their forks. This gives them credit and is simpler than going through the hoops to make their PRs pass through our CI pipeline. (They are missing the `Change-Type` footer, and some of them have merge conflicts that would otherwise result in an undesirable merge commit.)

