### PR TITLE
Enable the crt-static target feature for all targets

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build.env]
+passthrough = ["RUSTFLAGS=-C target-feature=+crt-static"]


### PR DESCRIPTION
We were relying on the fact that our current targets link the C runtime
statically. However, this may be different for other targets and could
even change in the future (e.g., see
https://github.com/rust-lang/compiler-team/issues/422).

With this commit we adopt the current recommendation, which is enabling
the crt-static target feature when building. See
https://doc.rust-lang.org/reference/linkage.html#static-and-dynamic-c-runtimes
for details.

Given the current defaults for Rust targets, this change should be a
no-op, but this shall make us safer and more resilient to Rust changes
in the long run.
