### PR TITLE
Add Jetson Xavier AGX/NX SD/NX eMMC balenaOS migration support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,3 +1696,4 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +258,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crc"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "finder"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9481e973e50f40460da705db000ad08fd16f9feb81325fb4a17b67ae834211b"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,12 +380,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -362,10 +411,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "futures-sink"
@@ -385,8 +456,11 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -410,6 +484,19 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "gptman"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597ab39960252358b1b1a6c38c9f8680e1950a7c3a9cdfe511172f0878ce2d95"
+dependencies = [
+ "bincode",
+ "crc",
+ "nix",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "h2"
@@ -1221,7 +1308,10 @@ version = "0.4.4"
 dependencies = [
  "cfg-if 0.1.10",
  "clap",
+ "finder",
  "flate2",
+ "futures",
+ "gptman",
  "lazy_static",
  "libc",
  "log",
@@ -1262,6 +1352,26 @@ dependencies = [
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1696,4 +1806,3 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+opt-level = "s"
+
 [dependencies]
 
 [dependencies.libc]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ publish = false
 [dependencies.libc]
 version = "0.2.70"
 
+[dependencies.finder]
+version = "0.1"
+
 [dependencies.reqwest]
 version = "0.11.24"
 features = ["blocking", "json"]
@@ -80,6 +83,7 @@ features = ["vendored"]
 raspberrypi3 = []
 raspberrypi4-64 = []
 intel-nuc = []
+jetson-xavier = []
 
 [dependencies.gptman]
 version = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,3 +81,12 @@ raspberrypi3 = []
 raspberrypi4-64 = []
 intel-nuc = []
 
+[dependencies.gptman]
+version = "1.0.2"
+
+# Required to get past "ambiguous name" errors in pin-project-internal v0.4.17.
+# See https://github.com/taiki-e/pin-project/issues/337
+# Problem was triggered by addition of gptman.
+# This package seems foundational and important to keep updated.
+[dependencies.futures]
+version = "0.3.30"

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,7 @@ use std::mem::MaybeUninit;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
+use finder::Finder;
 
 use log::{debug, error, trace, warn};
 
@@ -72,6 +73,21 @@ pub(crate) fn call(cmd: &str, args: &[&str], trim_stdout: bool) -> Result<CmdRes
             ))
         }
     }
+}
+
+// Helper function for finding a file inside directory
+pub(crate) fn find_file(file_name: &str, directory: &PathBuf) -> PathBuf {
+    let file_finder = Finder::new(directory.clone());
+    let mut file_path = PathBuf::new();
+
+    for i in file_finder.into_iter() {
+        if i.path().to_string_lossy().contains(file_name) {
+            file_path = i.path().to_path_buf();
+            break;
+        }
+    }
+
+    return file_path;
 }
 
 pub(crate) fn whereis(cmd: &str) -> Result<String> {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use finder::Finder;
 use std::cmp::min;
 use std::ffi::{CStr, CString, OsString};
 use std::fs::{read_to_string, OpenOptions};
@@ -6,7 +7,6 @@ use std::mem::MaybeUninit;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Stdio};
-use finder::Finder;
 
 use log::{debug, error, trace, warn};
 
@@ -76,8 +76,8 @@ pub(crate) fn call(cmd: &str, args: &[&str], trim_stdout: bool) -> Result<CmdRes
 }
 
 // Helper function for finding a file inside directory
-pub(crate) fn find_file(file_name: &str, directory: &PathBuf) -> PathBuf {
-    let file_finder = Finder::new(directory.clone());
+pub(crate) fn find_file(file_name: &str, directory: &Path) -> PathBuf {
+    let file_finder = Finder::new(directory);
     let mut file_path = PathBuf::new();
 
     for i in file_finder.into_iter() {
@@ -87,7 +87,7 @@ pub(crate) fn find_file(file_name: &str, directory: &PathBuf) -> PathBuf {
         }
     }
 
-    return file_path;
+    file_path
 }
 
 pub(crate) fn whereis(cmd: &str) -> Result<String> {

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -11,9 +11,10 @@ pub(crate) const BLKID_CMD: &str = "blkid";
 pub(crate) const EFIBOOTMGR_CMD: &str = "efibootmgr";
 pub(crate) const DD_CMD: &str = "dd";
 
-/* The mdtd_debug tool is used on Xavier NX devices to clear and write the QSPI
-   with the blob included in the target OS image
-*/
+// The mdtd_debug tool is used on Xavier NX devices to clear and write the QSPI
+// with the boot blob included in the target OS image.
+// This tools is provided by the mtd-utils package at
+// http://git.infradead.org/?p=mtd-utils.git
 pub(crate) const MTD_DEBUG_CMD: &str = "mtd_debug";
 
 pub(crate) const TAR_CMD: &str = "tar";
@@ -28,40 +29,57 @@ pub(crate) const BALENA_CONFIG_PATH: &str = "/config.json";
 
 pub const DISK_BY_LABEL_PATH: &str = "/dev/disk/by-label";
 
+// balena boot partition name
 pub const BALENA_BOOT_PART: &str = "resin-boot";
+
+// Default balena boot partition filesystem type
 pub const BALENA_BOOT_FSTYPE: &str = "vfat";
 
+// balena rootA partition name
 pub const BALENA_ROOTA_PART: &str = "resin-rootA";
-pub const BALENA_DATA_PART: &str = "resin-data";
-pub const BALENA_DATA_FSTYPE: &str = "ext4";
 
+// balena rootA partition filesystem type
 pub const BALENA_ROOTA_FSTYPE: &str = "ext4";
+
+// balena data partition name
+pub const BALENA_DATA_PART: &str = "resin-data";
+
+// balena data partition filesystem type
+pub const BALENA_DATA_FSTYPE: &str = "ext4";
 
 pub const OLD_ROOT_MP: &str = "/mnt/old_root";
 pub const BALENA_BOOT_MP: &str = "/mnt/balena-boot";
 pub const BALENA_PART_MP: &str = "/mnt/balena-part";
 
+// balena directory which holds NetworkManager connection files.
+// this directory is located in the resin-boot partition, in balenaOS
 pub const SYSTEM_CONNECTIONS_DIR: &str = "system-connections";
+
+// balena directory which holds redsocks proxy configuration files
 pub const SYSTEM_PROXY_DIR: &str = "system-proxy";
 
+// default mountpoint for the balenaOS data partition
 pub const BALENA_DATA_MP: &str = "/mnt/data/";
 pub const BALENA_OS_NAME: &str = "balenaOS";
 
 pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connections/";
 pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
 
-/* Enables writing to the hardware-defined boot partition on AGX Xavier */
+// Enables writing to the hardware-defined boot partition on AGX Xavier.
+// For details on boot partitions access in Linux,
+// see https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt
 pub const JETSON_XAVIER_HW_PART_FORCE_RO_FILE: &str = "/sys/block/mmcblk0boot0/force_ro";
 
-/* Hardware-defined boot partition for Jetson AGX Xavier */
+// Hardware-defined boot partition for Jetson AGX Xavier
 pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
 
-/* QSPI device - Jetson Xavier NX SD and NX eMMC */
+// QSPI device - Jetson Xavier NX SD and NX eMMC
 pub const BOOT_BLOB_PARTITION_JETSON_XAVIER_NX: &str = "/dev/mtd0";
 
-/* Stage 2 boot blob file names on AGX Xavier and Xavier NX. These are used
-   for programming the QSPI
- */
+// Stage 2 boot blob file names on AGX Xavier and Xavier NX. These are used
+// for programming the QSPI, are provided by the target balenaOS image we migrate
+// to, and they've been obtained from a device flashed with balenaOS using
+// the Nvidia flashing tools.
 pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
 pub const BOOT_BLOB_NAME_JETSON_XAVIER_NX: &str = "boot0_mtdblock0.img";
 

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -11,6 +11,11 @@ pub(crate) const BLKID_CMD: &str = "blkid";
 pub(crate) const EFIBOOTMGR_CMD: &str = "efibootmgr";
 pub(crate) const DD_CMD: &str = "dd";
 
+/* The mdtd_debug tool is used on Xavier NX devices to clear and write the QSPI
+   with the blob included in the target OS image
+*/
+pub(crate) const MTD_DEBUG_CMD: &str = "mtd_debug";
+
 pub(crate) const TAR_CMD: &str = "tar";
 
 pub(crate) const TAKEOVER_DIR: &str = "/balena-takeover";
@@ -26,14 +31,39 @@ pub const DISK_BY_LABEL_PATH: &str = "/dev/disk/by-label";
 pub const BALENA_BOOT_PART: &str = "resin-boot";
 pub const BALENA_BOOT_FSTYPE: &str = "vfat";
 
+pub const BALENA_ROOTA_PART: &str = "resin-rootA";
 pub const BALENA_DATA_PART: &str = "resin-data";
 pub const BALENA_DATA_FSTYPE: &str = "ext4";
+
+pub const BALENA_ROOTA_FSTYPE: &str = "ext4";
 
 pub const OLD_ROOT_MP: &str = "/mnt/old_root";
 pub const BALENA_BOOT_MP: &str = "/mnt/balena-boot";
 pub const BALENA_PART_MP: &str = "/mnt/balena-part";
 
 pub const SYSTEM_CONNECTIONS_DIR: &str = "system-connections";
+pub const SYSTEM_PROXY_DIR: &str = "system-proxy";
+
+pub const BALENA_DATA_MP: &str = "/mnt/data/";
+pub const BALENA_OS_NAME: &str = "balenaOS";
+
+pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connections/";
+pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
+
+/* Enables writing to the hardware-defined boot partition on AGX Xavier */
+pub const JETSON_XAVIER_HW_PART_FORCE_RO_FILE: &str = "/sys/block/mmcblk0boot0/force_ro";
+
+/* Hardware-defined boot partition for Jetson AGX Xavier */
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER: &str = "/dev/mmcblk0boot0";
+
+/* QSPI device - Jetson Xavier NX SD and NX eMMC */
+pub const BOOT_BLOB_PARTITION_JETSON_XAVIER_NX: &str = "/dev/mtd0";
+
+/* Stage 2 boot blob file names on AGX Xavier and Xavier NX. These are used
+   for programming the QSPI
+ */
+pub const BOOT_BLOB_NAME_JETSON_XAVIER: &str = "boot0_mmcblk0boot0.img";
+pub const BOOT_BLOB_NAME_JETSON_XAVIER_NX: &str = "boot0_mtdblock0.img";
 
 pub const SYS_EFI_DIR: &str = "/sys/firmware/efi";
 pub const SYS_EFIVARS_DIR: &str = "/sys/firmware/efi/efivars";

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -19,7 +19,8 @@ pub(crate) const MTD_DEBUG_CMD: &str = "mtd_debug";
 
 pub(crate) const TAR_CMD: &str = "tar";
 
-pub(crate) const TAKEOVER_DIR: &str = "/balena-takeover";
+// below path is used as the root mountpoint during migration
+pub(crate) const TAKEOVER_DIR: &str = "/tmp/balena-takeover";
 pub(crate) const STAGE2_CONFIG_NAME: &str = "stage2-config.yml";
 
 pub(crate) const BALENA_IMAGE_NAME: &str = "balena.img.gz";

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -286,7 +286,7 @@ impl<'a> PartitionIterator<'a> {
                     self.part_idx = 4;
                     self.get_extended_partition()
                 }
-                PartitionType::Fat | PartitionType::Linux => {
+                PartitionType::Fat | PartitionType::Linux | PartitionType::GPT => {
                     // return regular partition
                     self.index += 1;
                     self.part_idx += 1;
@@ -475,6 +475,7 @@ impl<'a> Read for PartitionReader<'a> {
             }
         }
     }
+
 }
 
 #[cfg(test)]

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -475,7 +475,6 @@ impl<'a> Read for PartitionReader<'a> {
             }
         }
     }
-
 }
 
 #[cfg(test)]

--- a/src/common/disk_util.rs
+++ b/src/common/disk_util.rs
@@ -1,8 +1,11 @@
 use log::{debug, error, trace};
+use std::fs::File;
 use std::io::{self, Read};
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::result;
+
+use gptman::GPT;
 
 use crate::common::{Error, ErrorKind, Result};
 
@@ -28,7 +31,7 @@ pub(crate) use plain_file::PlainFile;
 pub(crate) const DEF_BLOCK_SIZE: usize = 512;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum LabelType {
     GPT,
     Dos,
@@ -214,6 +217,12 @@ impl Disk {
         }
 
         Ok(mbr)
+    }
+
+    pub fn read_gpt(&mut self) -> gptman::Result<GPT> {
+        let mut f = File::open(self.get_image_file())?;
+        //let len = f.seek(SeekFrom::End(0))?;
+        GPT::find_from(&mut f)
     }
 }
 
@@ -483,7 +492,7 @@ mod test {
 
         // iterate up the path to find project root
         let ancestors: Vec<&Path> = test_path.ancestors().collect();
-        test_path = test_path.parent().unwrap();
+        //test_path = test_path.parent().unwrap();
 
         ancestors.iter().rev().find(|dir| {
             test_path = test_path.parent().unwrap();

--- a/src/common/options.rs
+++ b/src/common/options.rs
@@ -26,6 +26,13 @@ pub struct Options {
     )]
     image: Option<PathBuf>,
     #[clap(
+        long = "ldd-path",
+        value_name = "LDD_PATH",
+        value_parser,
+        help = "Path to ldd script"
+    )]
+    ldd_path: Option<PathBuf>,
+    #[clap(
         short,
         long,
         value_name = "VERSION",
@@ -168,6 +175,14 @@ impl Options {
 
     pub fn image(&self) -> &Option<PathBuf> {
         &self.image
+    }
+
+    pub fn ldd_path(&self) -> PathBuf {
+        if let Some(ldd_path) = &self.ldd_path {
+            ldd_path.clone()
+        } else {
+            PathBuf::from("")
+        }
     }
 
     pub fn version(&self) -> &str {

--- a/src/common/stage2_config.rs
+++ b/src/common/stage2_config.rs
@@ -28,6 +28,7 @@ pub(crate) struct Stage2Config {
     pub image_path: PathBuf,
     pub config_path: PathBuf,
     pub backup_path: Option<PathBuf>,
+    pub device_type: String,
     pub tty: PathBuf,
 }
 

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -1,5 +1,5 @@
 use libc::{
-    self, ino_t, mode_t, utsname, EACCES, EEXIST, ENOENT, ENXIO, EPERM, O_RDONLY, S_IFBLK, S_IFCHR,
+    self, ino_t, mode_t, utsname, EACCES, EEXIST, ENOENT, ENXIO, EPERM, EIO, O_RDONLY, S_IFBLK, S_IFCHR,
     S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
 
@@ -55,6 +55,7 @@ fn sys_error(message: &str) -> Error {
         ENOENT => ErrorKind::FileNotFound,
         ENXIO => ErrorKind::DeviceNotFound,
         EEXIST => ErrorKind::FileExists,
+        EIO=> ErrorKind::CmdIo,
         _ => ErrorKind::Upstream,
     };
     Error::with_all(error_kind, message, Box::new(io::Error::last_os_error()))
@@ -391,7 +392,7 @@ pub(crate) fn fuser<P: AsRef<Path>>(
         sleep(if let Some(wait_for_term) = wait_for_term {
             wait_for_term
         } else {
-            Duration::from_millis(500)
+            Duration::from_millis(3000)
         });
         let mut kill_count = 0;
         for pid in sent_signals {

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -392,6 +392,7 @@ pub(crate) fn fuser<P: AsRef<Path>>(
         sleep(if let Some(wait_for_term) = wait_for_term {
             wait_for_term
         } else {
+            // balena-engine can take a bit longer to stop, compared to other processes
             Duration::from_millis(3000)
         });
         let mut kill_count = 0;

--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -1,6 +1,6 @@
 use libc::{
-    self, ino_t, mode_t, utsname, EACCES, EEXIST, ENOENT, ENXIO, EPERM, EIO, O_RDONLY, S_IFBLK, S_IFCHR,
-    S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
+    self, ino_t, mode_t, utsname, EACCES, EEXIST, EIO, ENOENT, ENXIO, EPERM, O_RDONLY, S_IFBLK,
+    S_IFCHR, S_IFDIR, S_IFIFO, S_IFLNK, S_IFMT, S_IFREG, S_IFSOCK,
 };
 
 use std::collections::HashMap;
@@ -55,7 +55,7 @@ fn sys_error(message: &str) -> Error {
         ENOENT => ErrorKind::FileNotFound,
         ENXIO => ErrorKind::DeviceNotFound,
         EEXIST => ErrorKind::FileExists,
-        EIO=> ErrorKind::CmdIo,
+        EIO => ErrorKind::CmdIo,
         _ => ErrorKind::Upstream,
     };
     Error::with_all(error_kind, message, Box::new(io::Error::last_os_error()))
@@ -358,7 +358,10 @@ pub(crate) fn fuser<P: AsRef<Path>>(
                                         } else {
                                             return Err(Error::with_context(
                                                 ErrorKind::InvState,
-                                                &format!("file '{}' is not a link", curr_path.display()),
+                                                &format!(
+                                                    "file '{}' is not a link",
+                                                    curr_path.display()
+                                                ),
                                             ));
                                         }
                                     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,8 +1,6 @@
 use crate::{
     common::{
-        call,
-        defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR},
-        get_mountpoint, path_append, whereis, Error, Result, ToError, get_os_name,
+        call, defs::{BALENA_DATA_MP, BALENA_OS_NAME, MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR}, get_mountpoint, get_os_name, path_append, whereis, Error, Result, ToError
     },
     stage2::{read_stage2_config, reboot},
     ErrorKind,
@@ -107,7 +105,7 @@ fn redirect_fd(file_name: &str, old_fd: c_int, mode: c_int) -> Result<()> {
         .into_raw();
 
     let new_fd = unsafe { open(filename, mode) };
-    let _ = unsafe { CString::from_raw(filename) };
+
     if new_fd >= 0 {
         let res = unsafe { dup2(new_fd, old_fd) };
         if res >= 0 {
@@ -220,8 +218,8 @@ pub fn init() -> ! {
     let mut takeover_path = PathBuf::from("");
     match get_os_name() {
         Ok(name) => {
-            if name.starts_with("balenaOS") {
-                takeover_path.push("/mnt/boot");
+            if name.starts_with(BALENA_OS_NAME) {
+                takeover_path.push(BALENA_DATA_MP);
             }
         }
         Err(_) => {

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,6 +1,8 @@
 use crate::{
     common::{
-        call, defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR}, get_mountpoint, path_append, whereis, Error, Result, ToError
+        call,
+        defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR},
+        get_mountpoint, path_append, whereis, Error, Result, ToError,
     },
     stage2::{read_stage2_config, reboot},
     ErrorKind,
@@ -19,11 +21,11 @@ use std::fs::create_dir_all;
 use std::io;
 use std::mem::MaybeUninit;
 use std::os::raw::c_int;
+use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
-use std::path::{PathBuf};
 
 use crate::common::stage2_config::LogDevice;
 use libc::{
@@ -220,7 +222,8 @@ pub fn init() -> ! {
     if let Err(why) = set_current_dir(&takeover_path) {
         error!(
             "Failed to change to directory '{}', error: {:?}",
-            takeover_path.display(), why
+            takeover_path.display(),
+            why
         );
         reboot();
     }

--- a/src/init.rs
+++ b/src/init.rs
@@ -2,7 +2,7 @@ use crate::{
     common::{
         call,
         defs::{MOUNT_CMD, NIX_NONE, PIVOT_ROOT_CMD, TAKEOVER_DIR},
-        get_mountpoint, path_append, whereis, Error, Result, ToError,
+        get_mountpoint, path_append, whereis, Error, Result, ToError, get_os_name,
     },
     stage2::{read_stage2_config, reboot},
     ErrorKind,
@@ -25,6 +25,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
+use std::path::{PathBuf};
 
 use crate::common::stage2_config::LogDevice;
 use libc::{
@@ -34,7 +35,7 @@ use libc::{
 
 const INITIAL_LOG_LEVEL: Level = Level::Trace;
 
-fn setup_log(log_dev: &LogDevice) -> Result<()> {
+fn setup_log(log_dev: &LogDevice, takeover_dir: &str) -> Result<()> {
     trace!(
         "setup_log entered with '{}', fs type: {}",
         log_dev.dev_name.display(),
@@ -54,7 +55,7 @@ fn setup_log(log_dev: &LogDevice) -> Result<()> {
             }
         }
 
-        let mountpoint = path_append(TAKEOVER_DIR, "/mnt/log");
+        let mountpoint = path_append(takeover_dir, "/mnt/log");
         create_dir_all(&mountpoint)
             .upstream_with_context("Failed to create log mount directory /mnt/log")?;
 
@@ -134,7 +135,7 @@ fn redirect_fd(file_name: &str, old_fd: c_int, mode: c_int) -> Result<()> {
     }
 }
 
-fn close_fds() -> Result<i32> {
+fn close_fds(takeover_dir: &str) -> Result<i32> {
     let mut pipe_fds: [c_int; 2] = [0; 2];
     let sys_rc = unsafe { pipe(pipe_fds.as_mut_ptr()) };
 
@@ -162,12 +163,12 @@ fn close_fds() -> Result<i32> {
     }
 
     redirect_fd(
-        &format!("{}/stdout.log", TAKEOVER_DIR),
+        &format!("{}/stdout.log", takeover_dir),
         STDOUT_FILENO,
         O_WRONLY | O_CREAT | O_TRUNC,
     )?;
     redirect_fd(
-        &format!("{}/stderr.log", TAKEOVER_DIR),
+        &format!("{}/stderr.log", takeover_dir),
         STDERR_FILENO,
         O_WRONLY | O_CREAT | O_TRUNC,
     )?;
@@ -216,15 +217,34 @@ pub fn init() -> ! {
 
     info!("Init check pid success!");
 
-    if let Err(why) = set_current_dir(TAKEOVER_DIR) {
+    let mut takeover_path = PathBuf::from("");
+    match get_os_name() {
+        Ok(name) => {
+            if name.starts_with("balenaOS") {
+                takeover_path.push("/mnt/boot");
+            }
+        }
+        Err(_) => {
+            error!("Can't determine operating system name");
+            reboot();
+        }
+    }
+    if TAKEOVER_DIR.starts_with("/") {
+        takeover_path.push(TAKEOVER_DIR[1..].to_string());
+    } else {
+        takeover_path.push(TAKEOVER_DIR);
+    }
+    let takeover_dir = takeover_path.to_str().unwrap_or(TAKEOVER_DIR);
+
+    if let Err(why) = set_current_dir(&takeover_path) {
         error!(
             "Failed to change to directory '{}', error: {:?}",
-            TAKEOVER_DIR, why
+            takeover_path.display(), why
         );
         reboot();
     }
 
-    let s2_config = match read_stage2_config(Some(TAKEOVER_DIR)) {
+    let s2_config = match read_stage2_config(Some(&takeover_path)) {
         Ok(s2_config) => s2_config,
         Err(why) => {
             error!("Failed to read stage2 configuration, error: {:?}", why);
@@ -243,7 +263,7 @@ pub fn init() -> ! {
         }
     }
 
-    let closed_fds = match close_fds() {
+    let closed_fds = match close_fds(takeover_dir) {
         Ok(fds) => fds,
         Err(_) => {
             error!("Failed close open files");
@@ -253,7 +273,7 @@ pub fn init() -> ! {
     info!("Stage 2 closed {} fd's", closed_fds);
 
     let ext_log = if let Some(log_dev) = s2_config.log_dev() {
-        match setup_log(log_dev) {
+        match setup_log(log_dev, takeover_dir) {
             Ok(_) => true,
             Err(why) => {
                 error!("Setup log failed, error: {:?}", why);

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -19,7 +19,6 @@ use nix::{
 };
 
 use libc::MS_BIND;
-
 use log::{debug, error, info, warn, Level};
 
 use which::which;
@@ -42,8 +41,8 @@ use crate::{
     common::{
         call,
         defs::{
-            NIX_NONE, OLD_ROOT_MP, STAGE2_CONFIG_NAME, SWAPOFF_CMD, SYSTEM_CONNECTIONS_DIR,
-            SYS_EFIVARS_DIR, SYS_EFI_DIR, TELINIT_CMD,
+            NIX_NONE, OLD_ROOT_MP, STAGE2_CONFIG_NAME, SWAPOFF_CMD, SYSTEM_CONNECTIONS_DIR, SYSTEM_PROXY_DIR,
+            SYS_EFIVARS_DIR, SYS_EFI_DIR, TELINIT_CMD, BALENA_OS_NAME, BALENA_DATA_MP, BALENA_SYSTEM_CONNECTIONS_BOOT_PATH, BALENA_SYSTEM_PROXY_BOOT_PATH,
         },
         error::{Error, ErrorKind, Result, ToError},
         file_exists, format_size_with_unit, get_mem_info, is_admin, get_os_name,
@@ -58,7 +57,7 @@ use crate::{
     },
 };
 
-use crate::common::defs::{DD_CMD, EFIBOOTMGR_CMD, TAKEOVER_DIR};
+use crate::common::defs::{DD_CMD, EFIBOOTMGR_CMD, MTD_DEBUG_CMD, TAKEOVER_DIR};
 use crate::common::dir_exists;
 use crate::common::stage2_config::LogDevice;
 use crate::common::system::{is_dir, mkdir, stat};
@@ -76,18 +75,65 @@ fn prepare_configs<P1: AsRef<Path>>(
     mig_info.update_config()?;
 
     // *********************************************************
-    // write network_manager filess to tmpfs
+    // write network_manager files to tmpfs
     let mut nwmgr_cfgs: u64 = 0;
     let nwmgr_path = path_append(work_dir, SYSTEM_CONNECTIONS_DIR);
+    let sys_proxy_copy_path = path_append(work_dir, SYSTEM_PROXY_DIR);
     create_dir_all(&nwmgr_path).upstream_with_context(&format!(
         "Failed to create directory '{}",
         nwmgr_path.display()
     ))?;
 
+    create_dir_all(&sys_proxy_copy_path).upstream_with_context(&format!(
+        "Failed to create directory '{}",
+        nwmgr_path.display()
+    ))?;
+
+    /* If migrating from balenaOS, copy all files from the system-connections file in /mnt/boot
+     * TODO: Check if we should copy them from the boot partition, or from the NM root overlay directory
+     */
+    if mig_info.os_name().starts_with(BALENA_OS_NAME) {
+        debug!("migrating from balenaOS - copying system-connections files");
+        let  nwmgr_files = read_dir(BALENA_SYSTEM_CONNECTIONS_BOOT_PATH).unwrap();
+        for path in nwmgr_files {
+            mig_info.add_nwmgr_file(path.unwrap().path());
+        }
+
+        debug!("migrating from balenaOS - copying system-proxy files");
+        let system_proxy_files = read_dir(BALENA_SYSTEM_PROXY_BOOT_PATH).unwrap();
+        for sys_proxy_path in system_proxy_files {
+            mig_info.add_system_proxy_file(sys_proxy_path.unwrap().path());
+        }
+    }
+
+    for proxy_file in mig_info.system_proxy_files() {
+        let target_file_name = Path::new(&proxy_file).file_name().unwrap().to_str().unwrap();
+        let target_file = path_append(&sys_proxy_copy_path, target_file_name);
+
+        copy(&proxy_file, &target_file).upstream_with_context(&format!(
+           "Failed to copy '{}' to '{}'",
+           proxy_file.display(),
+           target_file.display()
+       ))?;
+       info!(
+           "Copied '{}' to '{}'",
+           proxy_file.display(),
+           target_file.display()
+       );
+    }
+
     for source_file in mig_info.nwmgr_files() {
         nwmgr_cfgs += 1;
-        let target_file = path_append(&nwmgr_path, &format!("balena-{:02}", nwmgr_cfgs));
-        copy(source_file, &target_file).upstream_with_context(&format!(
+        let target_file ;
+
+        /* If migrating from balenaOS, preserve file names for all entries in system-connections/ */
+        if !mig_info.os_name().starts_with("balenaOS") {
+            target_file = path_append(&nwmgr_path, &format!("balena-{:02}", nwmgr_cfgs));
+        } else {
+            let target_file_name = Path::new(source_file).file_name().unwrap().to_str().unwrap();
+            target_file = path_append(&nwmgr_path, target_file_name);
+        }
+        copy(&source_file, &target_file).upstream_with_context(&format!(
             "Failed to copy '{}' to '{}'",
             source_file.display(),
             target_file.display()
@@ -232,11 +278,17 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     let mut req_space: u64 = 0;
     let mut copy_commands = vec![DD_CMD];
-    if mig_info.is_x86() && !opts.no_efi_setup() && dir_exists(SYS_EFI_DIR)? {
+
+    /* If device is a Jetson Xavier, don't copy over efibootmgr because the old L4T does not use EFI */
+    if mig_info.is_x86() && !opts.no_efi_setup() && !mig_info.is_jetson_xavier() && dir_exists(SYS_EFI_DIR)? {
         copy_commands.push(EFIBOOTMGR_CMD)
     }
 
-    let commands = match ExeCopy::new(copy_commands) {
+    if mig_info.is_jetson_xavier_nx() {
+        copy_commands.push(MTD_DEBUG_CMD)
+    }
+
+    let commands = match ExeCopy::new(copy_commands, opts) {
         Ok(commands) => {
             let cmd_space = commands.get_req_space();
             debug!(
@@ -273,9 +325,9 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     // *********************************************************
     // make mountpoint for tmpfs
     let mut takeover_dir = PathBuf::from("");
-    if get_os_name()?.starts_with("balenaOS") {
+    if mig_info.os_name().starts_with(BALENA_OS_NAME) {
         // base directory for mountpoint must be writeable
-        takeover_dir.push("/mnt/boot");
+        takeover_dir.push(BALENA_DATA_MP);
     }
     if TAKEOVER_DIR.starts_with("/") {
         takeover_dir.push(TAKEOVER_DIR[1..].to_string());
@@ -324,7 +376,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     mig_info.set_to_dir(&takeover_dir);
 
-    info!("Using '{}' as takeover directory", takeover_dir.display());
+    info!("Using '{}' as takeover directory on '{}'", takeover_dir.display(), mig_info.os_name());
 
     mount_sys_filesystems(&takeover_dir, mig_info, opts)?;
 
@@ -354,9 +406,9 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     let new_init_path = path_append(&takeover_dir, format!("/bin/{}", env!("CARGO_PKG_NAME")));
     // Assets::write_stage2_script(&takeover_dir, &new_init_path, &tty, opts.get_s2_log_level())?;
 
-    let block_dev_info = if get_os_name()?.starts_with("balenaOS") {
+    let block_dev_info = if get_os_name()?.starts_with(BALENA_OS_NAME) {
         // can't use default root dir due to overlayfs
-        BlockDeviceInfo::new_for_dir("/mnt/boot")?
+        BlockDeviceInfo::new_for_dir(BALENA_DATA_MP)?
     } else {
         BlockDeviceInfo::new()?
     };
@@ -440,7 +492,12 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
             ))?,
         image_path: mig_info.image_path().to_path_buf(),
         config_path: mig_info.balena_cfg().get_path().to_path_buf(),
-        backup_path: mig_info.backup().map(|backup_path| backup_path.to_owned()),
+        backup_path: if let Some(backup_path) = mig_info.backup() {
+            Some(backup_path.to_owned())
+        } else {
+            None
+        },
+        device_type: mig_info.get_device_type_name().to_string(),
         tty: read_link("/proc/self/fd/1")
             .upstream_with_context("Failed to read tty from '/proc/self/fd/1'")?,
     };

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -323,16 +323,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     // *********************************************************
     // make mountpoint for tmpfs
-    let mut takeover_dir = PathBuf::from("");
-    if mig_info.os_name().starts_with(BALENA_OS_NAME) {
-        // base directory for mountpoint must be writeable
-        takeover_dir.push(BALENA_DATA_MP);
-    }
-    if TAKEOVER_DIR.starts_with("/") {
-        takeover_dir.push(TAKEOVER_DIR[1..].to_string());
-    } else {
-        takeover_dir.push(TAKEOVER_DIR);
-    }
+    let takeover_dir = PathBuf::from(TAKEOVER_DIR);
 
     match stat(&takeover_dir) {
         Ok(stat) => {

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -46,7 +46,7 @@ use crate::{
             SYS_EFIVARS_DIR, SYS_EFI_DIR, TELINIT_CMD,
         },
         error::{Error, ErrorKind, Result, ToError},
-        file_exists, format_size_with_unit, get_mem_info, is_admin,
+        file_exists, format_size_with_unit, get_mem_info, is_admin, get_os_name,
         options::Options,
         path_append,
         stage2_config::{Stage2Config, UmountPart},
@@ -272,7 +272,17 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
 
     // *********************************************************
     // make mountpoint for tmpfs
-    let takeover_dir = PathBuf::from(TAKEOVER_DIR);
+    let mut takeover_dir = PathBuf::from("");
+    if get_os_name()?.starts_with("balenaOS") {
+        // base directory for mountpoint must be writeable
+        takeover_dir.push("/mnt/boot");
+    }
+    if TAKEOVER_DIR.starts_with("/") {
+        takeover_dir.push(TAKEOVER_DIR[1..].to_string());
+    } else {
+        takeover_dir.push(TAKEOVER_DIR);
+    }
+
     match stat(&takeover_dir) {
         Ok(stat) => {
             if is_dir(&stat) {
@@ -344,7 +354,12 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     let new_init_path = path_append(&takeover_dir, format!("/bin/{}", env!("CARGO_PKG_NAME")));
     // Assets::write_stage2_script(&takeover_dir, &new_init_path, &tty, opts.get_s2_log_level())?;
 
-    let block_dev_info = BlockDeviceInfo::new()?;
+    let block_dev_info = if get_os_name()?.starts_with("balenaOS") {
+        // can't use default root dir due to overlayfs
+        BlockDeviceInfo::new_for_dir("/mnt/boot")?
+    } else {
+        BlockDeviceInfo::new()?
+    };
 
     let flash_dev = if let Some(flash_dev) = opts.flash_to() {
         if let Some(flash_dev) = block_dev_info.get_devices().get(flash_dev) {

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -89,9 +89,8 @@ fn prepare_configs<P1: AsRef<Path>>(
         nwmgr_path.display()
     ))?;
 
-    /* If migrating from balenaOS, copy all files from the system-connections file in /mnt/boot
-     * TODO: Check if we should copy them from the boot partition, or from the NM root overlay directory
-     */
+    // If migrating from balenaOS, copy all files from the system-connections file in /mnt/boot
+    // TODO: Check if we should copy them from the boot partition, or from the NM root overlay directory
     if mig_info.os_name().starts_with(BALENA_OS_NAME) {
         debug!("migrating from balenaOS - copying system-connections files");
         let  nwmgr_files = read_dir(BALENA_SYSTEM_CONNECTIONS_BOOT_PATH).unwrap();
@@ -126,7 +125,7 @@ fn prepare_configs<P1: AsRef<Path>>(
         nwmgr_cfgs += 1;
         let target_file ;
 
-        /* If migrating from balenaOS, preserve file names for all entries in system-connections/ */
+        // If migrating from balenaOS, preserve file names for all entries in system-connections/
         if !mig_info.os_name().starts_with("balenaOS") {
             target_file = path_append(&nwmgr_path, &format!("balena-{:02}", nwmgr_cfgs));
         } else {
@@ -279,7 +278,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     let mut req_space: u64 = 0;
     let mut copy_commands = vec![DD_CMD];
 
-    /* If device is a Jetson Xavier, don't copy over efibootmgr because the old L4T does not use EFI */
+    // If device is a Jetson Xavier, don't copy over efibootmgr because the old L4T does not use EFI
     if mig_info.is_x86() && !opts.no_efi_setup() && !mig_info.is_jetson_xavier() && dir_exists(SYS_EFI_DIR)? {
         copy_commands.push(EFIBOOTMGR_CMD)
     }

--- a/src/stage1/block_device_info.rs
+++ b/src/stage1/block_device_info.rs
@@ -112,8 +112,15 @@ pub(crate) struct BlockDeviceInfo {
 }
 
 impl BlockDeviceInfo {
+    /// Create a BlockDeviceInfo based on the storage device used for the root directory.
     pub fn new() -> Result<BlockDeviceInfo> {
-        let stat_res = stat("/").upstream_with_context("Failed to stat root")?;
+        BlockDeviceInfo::new_for_dir("/")
+    }
+
+    /// Create a BlockDeviceInfo based on the storage device used for the provided
+    /// directory.
+    pub fn new_for_dir(dir: &str) -> Result<BlockDeviceInfo> {
+        let stat_res = stat(dir).upstream_with_context(&format!("Failed to stat for {}", dir))?;
         let root_number = DeviceNum::new(stat_res.st_dev);
         let mounts = Mount::from_mtab()?;
 

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -10,11 +10,14 @@ pub const DEV_TYPE_RPI4_64: &str = "raspberrypi4-64";
 pub const DEV_TYPE_BBG: &str = "beaglebone-green";
 pub const DEV_TYPE_BBB: &str = "beaglebone-black";
 pub const DEV_TYPE_BBXM: &str = "beagleboard-xm";
+pub const DEV_TYPE_JETSON_XAVIER: &str = "jetson-xavier";
+pub const DEV_TYPE_JETSON_XAVIER_NX: &str = "jetson-xavier-nx-devkit";
+pub const DEV_TYPE_JETSON_XAVIER_NX_EMMC: &str = "jetson-xavier-nx-devkit-emmc";
 
 pub const MAX_CONFIG_JSON: usize = 2048;
 pub const GZIP_MAGIC_COOKIE: u16 = 0x1f8b;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum DeviceType {
     BeagleboneGreen,
     BeagleboneBlack,
@@ -25,6 +28,8 @@ pub(crate) enum DeviceType {
     RaspberryPi3,
     RaspberryPi4,
     Dummy,
+    JetsonXavier,
+    JetsonXavierNX,
 }
 
 impl Display for DeviceType {
@@ -42,6 +47,8 @@ impl Display for DeviceType {
                 Self::RaspberryPi3 => "Raspberry Pi 3",
                 Self::RaspberryPi4 => "Raspberry Pi 4",
                 Self::Dummy => "Dummy",
+                Self::JetsonXavier => "Jetson Xavier AGX",
+                Self::JetsonXavierNX => "Jetson Xavier NX",
             }
         )
     }

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Display};
 
 pub const DEV_TYPE_INTEL_NUC: &str = "intel-nuc";
-pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext";
+pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext";   // MBR
+pub const DEV_TYPE_GEN_AMD64: &str = "generic-amd64";        // GPT
 pub const DEV_TYPE_RPI3: &str = "raspberrypi3";
 pub const DEV_TYPE_RPI2: &str = "raspberry-pi2";
 pub const DEV_TYPE_RPI1: &str = "raspberry-pi";

--- a/src/stage1/defs.rs
+++ b/src/stage1/defs.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Display};
 
 pub const DEV_TYPE_INTEL_NUC: &str = "intel-nuc";
-pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext";   // MBR
-pub const DEV_TYPE_GEN_AMD64: &str = "generic-amd64";        // GPT
+pub const DEV_TYPE_GEN_X86_64: &str = "genericx86-64-ext"; // MBR
+pub const DEV_TYPE_GEN_AMD64: &str = "generic-amd64"; // GPT
 pub const DEV_TYPE_RPI3: &str = "raspberrypi3";
 pub const DEV_TYPE_RPI2: &str = "raspberry-pi2";
 pub const DEV_TYPE_RPI1: &str = "raspberry-pi";

--- a/src/stage1/device_impl.rs
+++ b/src/stage1/device_impl.rs
@@ -10,8 +10,8 @@ use crate::{
 mod beaglebone;
 mod dummy;
 mod intel_nuc;
-mod raspberrypi;
 mod jetson_xavier;
+mod raspberrypi;
 
 const DEVICE_TREE_MODEL: &str = "/proc/device-tree/model";
 

--- a/src/stage1/device_impl.rs
+++ b/src/stage1/device_impl.rs
@@ -11,6 +11,7 @@ mod beaglebone;
 mod dummy;
 mod intel_nuc;
 mod raspberrypi;
+mod jetson_xavier;
 
 const DEVICE_TREE_MODEL: &str = "/proc/device-tree/model";
 
@@ -68,6 +69,10 @@ pub(crate) fn get_device(opts: &Options) -> Result<Box<dyn Device>> {
             }
 
             if let Some(device) = beaglebone::is_bb(opts, &dev_tree_model)? {
+                return Ok(device);
+            }
+
+            if let Some(device) = jetson_xavier::is_jetson_xavier(opts, &dev_tree_model)? {
                 return Ok(device);
             }
 

--- a/src/stage1/device_impl/dummy.rs
+++ b/src/stage1/device_impl/dummy.rs
@@ -14,7 +14,10 @@ impl Dummy {
 
 impl Device for Dummy {
     fn supports_device_type(&self, _dev_type: &str) -> bool {
-        true
+        // When using the Dummy device type, we want to skip all DT-specific
+        // code. We achieve that by saying that the Dummy device type does not
+        // support any device type.
+        false
     }
     fn get_device_type(&self) -> DeviceType {
         DeviceType::Dummy

--- a/src/stage1/device_impl/intel_nuc.rs
+++ b/src/stage1/device_impl/intel_nuc.rs
@@ -5,7 +5,7 @@ use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_AMD64},
+        defs::{DeviceType, DEV_TYPE_GEN_AMD64, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC},
         device::Device,
         utils::is_secure_boot,
     },

--- a/src/stage1/device_impl/intel_nuc.rs
+++ b/src/stage1/device_impl/intel_nuc.rs
@@ -5,13 +5,13 @@ use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC},
+        defs::{DeviceType, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_AMD64},
         device::Device,
         utils::is_secure_boot,
     },
 };
 
-const X86_SLUGS: [&str; 2] = [DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_X86_64];
+const X86_SLUGS: [&str; 3] = [DEV_TYPE_INTEL_NUC, DEV_TYPE_GEN_X86_64, DEV_TYPE_GEN_AMD64];
 
 pub(crate) struct IntelNuc;
 
@@ -28,6 +28,7 @@ impl IntelNuc {
             "Ubuntu 14.04.5 LTS",
             "Ubuntu 14.04.6 LTS",
             "Manjaro Linux",
+            "balenaOS 4.0.23",
         ];
 
         if opts.migrate() {

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -1,15 +1,21 @@
-use log::{debug, trace};
 use crate::stage1::device_impl::check_os;
 use crate::{
     common::{Error, Options, Result},
     // linux_common::is_secure_boot,
     stage1::{
-        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER_NX_EMMC},
+        defs::{
+            DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX,
+            DEV_TYPE_JETSON_XAVIER_NX_EMMC,
+        },
         device::Device,
     },
 };
+use log::{debug, trace};
 
-pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Option<Box<dyn Device>>> {
+pub(crate) fn is_jetson_xavier(
+    opts: &Options,
+    model_string: &str,
+) -> Result<Option<Box<dyn Device>>> {
     trace!(
         "JetsonXavier::is_jetson_xavier: entered with model string: '{}'",
         model_string
@@ -22,8 +28,11 @@ pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Opt
     } else if model_string.eq("NVIDIA Jetson Xavier NX Developer Kit") {
         debug!("match found for Xavier NX Devkit");
         Ok(Some(Box::new(JetsonXavierNX::from_config(opts)?)))
-    } else  {
-        debug!("no match for Jetson-AGX or NVIDIA Jetson Xavier NX Developer Kit on: <{}>", model_string);
+    } else {
+        debug!(
+            "no match for Jetson-AGX or NVIDIA Jetson Xavier NX Developer Kit on: <{}>",
+            model_string
+        );
         Ok(None)
     }
 }
@@ -35,24 +44,19 @@ pub(crate) struct JetsonXavier;
 
 impl JetsonXavier {
     pub fn from_config(opts: &Options) -> Result<JetsonXavier> {
-        const SUPPORTED_OSSES: &[&str] = &[
-                   "balenaOS 5.1.20",
-                   "balenaOS 3.1.3+rev1",
-        ];
+        const SUPPORTED_OSSES: &[&str] = &["balenaOS 5.1.20", "balenaOS 3.1.3+rev1"];
 
-        if opts.migrate() {
-            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
-                return Err(Error::displayed());
-            }
-            // **********************************************************************
-            // ** Xavier AGX specific initialisation/checks
-            // **********************************************************************
+        if opts.migrate() && !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+            return Err(Error::displayed());
         }
+        // **********************************************************************
+        // ** Xavier AGX specific initialisation/checks
+        // **********************************************************************
         Ok(JetsonXavier)
     }
 }
 
-impl<'a> Device for JetsonXavier {
+impl Device for JetsonXavier {
     fn supports_device_type(&self, dev_type: &str) -> bool {
         XAVIER_AGX_SLUGS.contains(&dev_type)
     }
@@ -65,24 +69,19 @@ pub(crate) struct JetsonXavierNX;
 
 impl JetsonXavierNX {
     pub fn from_config(opts: &Options) -> Result<JetsonXavierNX> {
-        const SUPPORTED_OSSES: &[&str] = &[
-                   "balenaOS 5.1.20",
-                   "balenaOS 3.1.3+rev1",
-        ];
+        const SUPPORTED_OSSES: &[&str] = &["balenaOS 5.1.20", "balenaOS 3.1.3+rev1"];
 
-        if opts.migrate() {
-            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
-                return Err(Error::displayed());
-            }
-            // **********************************************************************
-            // ** Xavier NX (SD and eMMC) specific initialisation/checks
-            // **********************************************************************
+        if opts.migrate() && !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+            return Err(Error::displayed());
         }
+        // **********************************************************************
+        // ** Xavier NX (SD and eMMC) specific initialisation/checks
+        // **********************************************************************
         Ok(JetsonXavierNX)
     }
 }
 
-impl<'a> Device for JetsonXavierNX {
+impl Device for JetsonXavierNX {
     fn supports_device_type(&self, dev_type: &str) -> bool {
         XAVIER_NX_SLUGS.contains(&dev_type)
     }

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -15,7 +15,7 @@ pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Opt
         model_string
     );
 
-    /* Below strings have been taken from the AGX Xavier 8GB Devkit and the Xavier NX SD/eMMC Devkits */
+    // Below strings have been taken from the AGX Xavier 8GB Devkit and the Xavier NX SD/eMMC Devkits
     if model_string.eq("Jetson-AGX") {
         debug!("match found for Xavier AGX");
         Ok(Some(Box::new(JetsonXavier::from_config(opts)?)))

--- a/src/stage1/device_impl/jetson_xavier.rs
+++ b/src/stage1/device_impl/jetson_xavier.rs
@@ -1,0 +1,92 @@
+use log::{debug, trace};
+use crate::stage1::device_impl::check_os;
+use crate::{
+    common::{Error, Options, Result},
+    // linux_common::is_secure_boot,
+    stage1::{
+        defs::{DeviceType, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER_NX_EMMC},
+        device::Device,
+    },
+};
+
+pub(crate) fn is_jetson_xavier(opts: &Options, model_string: &str) -> Result<Option<Box<dyn Device>>> {
+    trace!(
+        "JetsonXavier::is_jetson_xavier: entered with model string: '{}'",
+        model_string
+    );
+
+    /* Below strings have been taken from the AGX Xavier 8GB Devkit and the Xavier NX SD/eMMC Devkits */
+    if model_string.eq("Jetson-AGX") {
+        debug!("match found for Xavier AGX");
+        Ok(Some(Box::new(JetsonXavier::from_config(opts)?)))
+    } else if model_string.eq("NVIDIA Jetson Xavier NX Developer Kit") {
+        debug!("match found for Xavier NX Devkit");
+        Ok(Some(Box::new(JetsonXavierNX::from_config(opts)?)))
+    } else  {
+        debug!("no match for Jetson-AGX or NVIDIA Jetson Xavier NX Developer Kit on: <{}>", model_string);
+        Ok(None)
+    }
+}
+
+const XAVIER_AGX_SLUGS: [&str; 1] = [DEV_TYPE_JETSON_XAVIER];
+const XAVIER_NX_SLUGS: [&str; 2] = [DEV_TYPE_JETSON_XAVIER_NX, DEV_TYPE_JETSON_XAVIER_NX_EMMC];
+
+pub(crate) struct JetsonXavier;
+
+impl JetsonXavier {
+    pub fn from_config(opts: &Options) -> Result<JetsonXavier> {
+        const SUPPORTED_OSSES: &[&str] = &[
+                   "balenaOS 5.1.20",
+                   "balenaOS 3.1.3+rev1",
+        ];
+
+        if opts.migrate() {
+            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+                return Err(Error::displayed());
+            }
+            // **********************************************************************
+            // ** Xavier AGX specific initialisation/checks
+            // **********************************************************************
+        }
+        Ok(JetsonXavier)
+    }
+}
+
+impl<'a> Device for JetsonXavier {
+    fn supports_device_type(&self, dev_type: &str) -> bool {
+        XAVIER_AGX_SLUGS.contains(&dev_type)
+    }
+    fn get_device_type(&self) -> DeviceType {
+        DeviceType::JetsonXavier
+    }
+}
+
+pub(crate) struct JetsonXavierNX;
+
+impl JetsonXavierNX {
+    pub fn from_config(opts: &Options) -> Result<JetsonXavierNX> {
+        const SUPPORTED_OSSES: &[&str] = &[
+                   "balenaOS 5.1.20",
+                   "balenaOS 3.1.3+rev1",
+        ];
+
+        if opts.migrate() {
+            if !check_os(SUPPORTED_OSSES, opts, "balenaOS 5.1.20")? {
+                return Err(Error::displayed());
+            }
+            // **********************************************************************
+            // ** Xavier NX (SD and eMMC) specific initialisation/checks
+            // **********************************************************************
+        }
+        Ok(JetsonXavierNX)
+    }
+}
+
+impl<'a> Device for JetsonXavierNX {
+    fn supports_device_type(&self, dev_type: &str) -> bool {
+        XAVIER_NX_SLUGS.contains(&dev_type)
+    }
+    fn get_device_type(&self) -> DeviceType {
+        DeviceType::JetsonXavierNX
+    }
+}

--- a/src/stage1/exe_copy.rs
+++ b/src/stage1/exe_copy.rs
@@ -1,5 +1,7 @@
 use crate::common::system::stat;
-use crate::common::{call, dir_exists, path_append, whereis, Error, ErrorKind, Result, ToError, options::Options};
+use crate::common::{
+    call, dir_exists, options::Options, path_append, whereis, Error, ErrorKind, Result, ToError,
+};
 
 use lazy_static::lazy_static;
 use log::{debug, info, trace, warn};
@@ -13,13 +15,12 @@ pub(crate) struct ExeCopy {
     req_space: u64,
     libraries: HashSet<String>,
     executables: HashSet<String>,
-    ldd_script_path: PathBuf
+    ldd_script_path: PathBuf,
 }
 
 impl ExeCopy {
     pub fn new(cmd_list: Vec<&str>, opts: &Options) -> Result<ExeCopy> {
         trace!("new: entered with {:?}", cmd_list);
-
 
         let mut executables: HashSet<String> = HashSet::new();
 
@@ -41,7 +42,7 @@ impl ExeCopy {
             req_space: 0,
             libraries: HashSet::new(),
             executables,
-            ldd_script_path: opts.ldd_path()
+            ldd_script_path: opts.ldd_path(),
         };
 
         efi_files.get_libs_for()?;
@@ -54,14 +55,16 @@ impl ExeCopy {
 
     fn get_libs_for(&mut self) -> Result<()> {
         trace!("get_libs_for: entered");
-        let ldd_path: String;
-        if self.ldd_script_path.is_empty() {
+
+        let ldd_path: String = if self.ldd_script_path.is_empty() {
             debug!("lld path was not provided, will use the one from current OS, if available");
-            ldd_path = whereis("ldd").upstream_with_context("Failed to locate ldd executable, please provide path to ldd manually")?;
+            whereis("ldd").upstream_with_context(
+                "Failed to locate ldd executable, please provide path to ldd manually",
+            )?
         } else {
             debug!("Provided ldd path: {}", self.ldd_script_path.display());
-            ldd_path = self.ldd_script_path.as_path().display().to_string();
-        }
+            self.ldd_script_path.as_path().display().to_string()
+        };
         let mut check_libs: HashSet<String> = HashSet::new();
 
         // TODO: this_path processing

--- a/src/stage1/image_retrieval.rs
+++ b/src/stage1/image_retrieval.rs
@@ -20,7 +20,7 @@ use crate::{
         api_calls::{get_os_image, get_os_versions, Versions},
         defs::{
             DEV_TYPE_BBB, DEV_TYPE_BBG, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_RPI1,
-            DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64,
+            DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64, DEV_TYPE_JETSON_XAVIER,
         },
         migrate_info::balena_cfg_json::BalenaCfgJson,
     },
@@ -30,13 +30,14 @@ use crate::{
 use flate2::{Compression, GzBuilder};
 use nix::mount::{mount, umount, MsFlags};
 
-const FLASHER_DEVICES: [&str; 4] = [
+pub const FLASHER_DEVICES: [&str; 5] = [
     DEV_TYPE_INTEL_NUC,
     DEV_TYPE_GEN_X86_64,
     DEV_TYPE_BBG,
     DEV_TYPE_BBB,
+    DEV_TYPE_JETSON_XAVIER,
 ];
-const SUPPORTED_DEVICES: [&str; 8] = [
+const SUPPORTED_DEVICES: [&str; 9] = [
     DEV_TYPE_RPI3,
     DEV_TYPE_RPI2,
     DEV_TYPE_RPI4_64,
@@ -45,12 +46,14 @@ const SUPPORTED_DEVICES: [&str; 8] = [
     DEV_TYPE_GEN_X86_64,
     DEV_TYPE_BBG,
     DEV_TYPE_BBB,
+    DEV_TYPE_JETSON_XAVIER,
 ];
 
 const IMG_NAME_GEN_X86_64: &str = "resin-image-genericx86-64-ext.resinos-img";
 const IMG_NAME_INTEL_NUC: &str = "resin-image-genericx86-64.resinos-img";
 const IMG_NAME_BBG: &str = "resin-image-beaglebone-green.resinos-img";
 const IMG_NAME_BBB: &str = "resin-image-beaglebone-black.resinos-img";
+const IMG_NAME_JETSON_XAVIER: &str = "balena-image-jetson-xavier.balenaos-img";
 
 fn parse_versions(versions: &Versions) -> Vec<Version> {
     let mut sem_vers: Vec<Version> = versions
@@ -145,7 +148,7 @@ fn determine_version(ver_str: &str, versions: &Versions) -> Result<Version> {
     }
 }
 
-fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
+pub(crate) fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
     stream: Box<dyn Read>,
     image_file_name: P1,
     device_type: &str,
@@ -205,6 +208,7 @@ fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
             }
             DEV_TYPE_BBB => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBB),
             DEV_TYPE_BBG => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBG),
+            DEV_TYPE_JETSON_XAVIER => path_append(path_append(&mount_path, "opt"), IMG_NAME_JETSON_XAVIER),
             _ => {
                 return Err(Error::with_context(
                     ErrorKind::InvParam,

--- a/src/stage1/image_retrieval.rs
+++ b/src/stage1/image_retrieval.rs
@@ -19,8 +19,8 @@ use crate::{
     stage1::{
         api_calls::{get_os_image, get_os_versions, Versions},
         defs::{
-            DEV_TYPE_BBB, DEV_TYPE_BBG, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC, DEV_TYPE_RPI1,
-            DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64, DEV_TYPE_JETSON_XAVIER,
+            DEV_TYPE_BBB, DEV_TYPE_BBG, DEV_TYPE_GEN_X86_64, DEV_TYPE_INTEL_NUC,
+            DEV_TYPE_JETSON_XAVIER, DEV_TYPE_RPI1, DEV_TYPE_RPI2, DEV_TYPE_RPI3, DEV_TYPE_RPI4_64,
         },
         migrate_info::balena_cfg_json::BalenaCfgJson,
     },
@@ -208,7 +208,9 @@ pub(crate) fn extract_image<P1: AsRef<Path>, P2: AsRef<Path>>(
             }
             DEV_TYPE_BBB => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBB),
             DEV_TYPE_BBG => path_append(path_append(&mount_path, "opt"), IMG_NAME_BBG),
-            DEV_TYPE_JETSON_XAVIER => path_append(path_append(&mount_path, "opt"), IMG_NAME_JETSON_XAVIER),
+            DEV_TYPE_JETSON_XAVIER => {
+                path_append(path_append(&mount_path, "opt"), IMG_NAME_JETSON_XAVIER)
+            }
             _ => {
                 return Err(Error::with_context(
                     ErrorKind::InvParam,

--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -11,7 +11,10 @@ use crate::{
     stage1::{
         backup::config::backup_cfg_from_file,
         backup::{create, create_ext},
-        defs::{DEV_TYPE_GEN_X86_64, GZIP_MAGIC_COOKIE, MAX_CONFIG_JSON, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX},
+        defs::{
+            DEV_TYPE_GEN_X86_64, DEV_TYPE_JETSON_XAVIER, DEV_TYPE_JETSON_XAVIER_NX,
+            GZIP_MAGIC_COOKIE, MAX_CONFIG_JSON,
+        },
         device::Device,
         device_impl::get_device,
         image_retrieval::download_image,
@@ -52,13 +55,17 @@ impl MigrateInfo {
     pub fn new(opts: &Options) -> Result<MigrateInfo> {
         let device = get_device(opts)?;
         let os_name = get_os_name()?;
-        info!("Detected device type: {} running {}", device.get_device_type(), os_name);
+        info!(
+            "Detected device type: {} running {}",
+            device.get_device_type(),
+            os_name
+        );
 
         //If no config.json is passed in command line and we're running on balenaOS,
         // we can preserve the existing config.json
         let mut config = if let Some(balena_cfg) = opts.config() {
             BalenaCfgJson::new(balena_cfg)?
-        } else if get_os_name()?.starts_with("balenaOS"){
+        } else if get_os_name()?.starts_with("balenaOS") {
             BalenaCfgJson::new("/mnt/boot/config.json")?
         } else {
             match MigrateInfo::get_internal_cfg_json(&opts.work_dir()) {
@@ -117,7 +124,6 @@ impl MigrateInfo {
                 image_path.display()
             ))?
         };
-
 
         if !opts.migrate() {
             return Err(Error::with_context(
@@ -212,7 +218,7 @@ impl MigrateInfo {
     }
 
     pub fn get_device_type_name(&self) -> String {
-         self.device.to_string()
+        self.device.to_string()
     }
 
     pub fn is_x86(&self) -> bool {
@@ -264,15 +270,23 @@ impl MigrateInfo {
 
     // Adds NetworkManager files to the list of connection files to be transferred to the new OS
     pub fn add_nwmgr_file<P: AsRef<Path>>(&mut self, nwmgr_file_path: P) {
-        self.nwmgr_files.push(nwmgr_file_path.as_ref().to_path_buf());
-        debug!("Adding network connection file to copy list: {}", nwmgr_file_path.as_ref().to_path_buf().display());
+        self.nwmgr_files
+            .push(nwmgr_file_path.as_ref().to_path_buf());
+        debug!(
+            "Adding network connection file to copy list: {}",
+            nwmgr_file_path.as_ref().to_path_buf().display()
+        );
     }
 
     // Adds redsocks proxy configuration files to the list of system-proxy files to be transferred to the new OS
     // This is useful in the context of balenaOS to balenaOS migration
     pub fn add_system_proxy_file<P: AsRef<Path>>(&mut self, system_proxy_file_path: P) {
-        self.system_proxy_files.push(system_proxy_file_path.as_ref().to_path_buf());
-        debug!("Adding system proxy configuration file to copy list: {}", system_proxy_file_path.as_ref().to_path_buf().display());
+        self.system_proxy_files
+            .push(system_proxy_file_path.as_ref().to_path_buf());
+        debug!(
+            "Adding system proxy configuration file to copy list: {}",
+            system_proxy_file_path.as_ref().to_path_buf().display()
+        );
     }
 
     pub fn wifis(&self) -> &Vec<WifiConfig> {

--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -54,9 +54,8 @@ impl MigrateInfo {
         let os_name = get_os_name()?;
         info!("Detected device type: {} running {}", device.get_device_type(), os_name);
 
-        /* If no config.json is passed in command line and we're running on balenaOS,
-         * we can preserve the existing config.json
-         */
+        //If no config.json is passed in command line and we're running on balenaOS,
+        // we can preserve the existing config.json
         let mut config = if let Some(balena_cfg) = opts.config() {
             BalenaCfgJson::new(balena_cfg)?
         } else if get_os_name()?.starts_with("balenaOS"){
@@ -263,11 +262,14 @@ impl MigrateInfo {
         &self.system_proxy_files
     }
 
+    // Adds NetworkManager files to the list of connection files to be transferred to the new OS
     pub fn add_nwmgr_file<P: AsRef<Path>>(&mut self, nwmgr_file_path: P) {
         self.nwmgr_files.push(nwmgr_file_path.as_ref().to_path_buf());
         debug!("Adding network connection file to copy list: {}", nwmgr_file_path.as_ref().to_path_buf().display());
     }
 
+    // Adds redsocks proxy configuration files to the list of system-proxy files to be transferred to the new OS
+    // This is useful in the context of balenaOS to balenaOS migration
     pub fn add_system_proxy_file<P: AsRef<Path>>(&mut self, system_proxy_file_path: P) {
         self.system_proxy_files.push(system_proxy_file_path.as_ref().to_path_buf());
         debug!("Adding system proxy configuration file to copy list: {}", system_proxy_file_path.as_ref().to_path_buf().display());

--- a/src/stage1/migrate_info/balena_cfg_json.rs
+++ b/src/stage1/migrate_info/balena_cfg_json.rs
@@ -73,10 +73,15 @@ impl BalenaCfgJson {
         info!("Configured for fleet id: {}", self.get_app_id()?);
 
         let device_type = self.get_device_type()?;
-        if !device.supports_device_type(device_type.as_str()) {
-            error!("The devicetype configured in config.json ({}) is not supported by the detected device type {:?}",
+        if opts.dt_check() {
+            if !device.supports_device_type(device_type.as_str()) {
+                error!("The device type configured in config.json ({}) is not supported by the detected device type {:?}",
                    device_type, device.get_device_type());
-            return Err(Error::displayed());
+                return Err(Error::displayed());
+            }
+        } else {
+            info!("Device type configured in config.json is {}; skipping compatibility check due to --no-dt-check option",
+            device_type)
         }
 
         if opts.api_check() {


### PR DESCRIPTION
Add balenaOS to balenaOS migration support for Jetson Xavier AGX, NX SD and NX eMMC devices
    
In this PR we:

      - ensure the existing config.json is preserved during the migration
      - all connection files in /mnt/boot/system-connections are transferred from the old OS
      - all system-proxy files in /mnt/boot/system-proxy are transferred as well
      - the eMMC or SD-card of the above-mentioned devices is flashed with the new OS
      - the QSPI or eMMC boot partition is flashed with the boot blob from the new OS
    
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Tested on AGX Xavier with

```
mkdir migrate
PATH="${PATH}:/mnt/data/migrate/bin" ./takeover -i balena-image-jetson-xavier.balenaos-img.gz --no-nwmgr-check --log-file /mnt/data/migrate/stage1.log --log-level trace -l /dev/sda1 --s2-log-level trace
```
