### PR TITLE
stage1: Compare system-connection files and their contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "file_diff"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a7a908b8f32538a2143e59a6e4e2508988832d5d4d6f7c156b3cbc762643a5"
+
+[[package]]
 name = "filetime"
 version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1308,6 +1314,7 @@ version = "0.4.5"
 dependencies = [
  "cfg-if 0.1.10",
  "clap",
+ "file_diff",
  "finder",
  "flate2",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ version = "0.2.70"
 [dependencies.finder]
 version = "0.1"
 
+[dependencies.file_diff]
+version = "1.0.0"
+
 [dependencies.reqwest]
 version = "0.11.24"
 features = ["blocking", "json"]

--- a/src/common/defs.rs
+++ b/src/common/defs.rs
@@ -59,6 +59,9 @@ pub const SYSTEM_CONNECTIONS_DIR: &str = "system-connections";
 // balena directory which holds redsocks proxy configuration files
 pub const SYSTEM_PROXY_DIR: &str = "system-proxy";
 
+// default mountpoint for the balenaOS boot partition
+pub const BALENA_OS_BOOT_MP: &str = "/mnt/boot/";
+
 // default mountpoint for the balenaOS data partition
 pub const BALENA_DATA_MP: &str = "/mnt/data/";
 pub const BALENA_OS_NAME: &str = "balenaOS";
@@ -66,6 +69,7 @@ pub const BALENA_OS_NAME: &str = "balenaOS";
 pub const BALENA_SYSTEM_CONNECTIONS_BOOT_PATH: &str = "/mnt/boot/system-connections/";
 pub const BALENA_SYSTEM_PROXY_BOOT_PATH: &str = "/mnt/boot/system-proxy/";
 
+pub const BALENA_NETWORK_MANAGER_BIND_MOUNT: &str = "/etc/NetworkManager/";
 // Enables writing to the hardware-defined boot partition on AGX Xavier.
 // For details on boot partitions access in Linux,
 // see https://www.kernel.org/doc/Documentation/mmc/mmc-dev-parts.txt

--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -2,7 +2,7 @@ mod backup;
 
 use std::env::set_current_dir;
 use std::fs::{
-    copy, create_dir, create_dir_all, read_dir, read_link, remove_dir_all, symlink_metadata,
+    copy, create_dir, create_dir_all, read_dir, read_link, remove_dir_all, symlink_metadata, File,
     OpenOptions,
 };
 use std::io::Write;
@@ -37,13 +37,16 @@ mod image_retrieval;
 mod utils;
 mod wifi_config;
 
+use file_diff::diff_files;
+
 use crate::{
     common::{
         call,
         defs::{
-            BALENA_DATA_MP, BALENA_OS_NAME, BALENA_SYSTEM_CONNECTIONS_BOOT_PATH,
-            BALENA_SYSTEM_PROXY_BOOT_PATH, NIX_NONE, OLD_ROOT_MP, STAGE2_CONFIG_NAME, SWAPOFF_CMD,
-            SYSTEM_CONNECTIONS_DIR, SYSTEM_PROXY_DIR, SYS_EFIVARS_DIR, SYS_EFI_DIR, TELINIT_CMD,
+            BALENA_DATA_MP, BALENA_NETWORK_MANAGER_BIND_MOUNT, BALENA_OS_BOOT_MP, BALENA_OS_NAME,
+            BALENA_SYSTEM_CONNECTIONS_BOOT_PATH, BALENA_SYSTEM_PROXY_BOOT_PATH, NIX_NONE,
+            OLD_ROOT_MP, STAGE2_CONFIG_NAME, SWAPOFF_CMD, SYSTEM_CONNECTIONS_DIR, SYSTEM_PROXY_DIR,
+            SYS_EFIVARS_DIR, SYS_EFI_DIR, TELINIT_CMD,
         },
         error::{Error, ErrorKind, Result, ToError},
         file_exists, format_size_with_unit, get_mem_info, get_os_name, is_admin,
@@ -65,6 +68,75 @@ use crate::common::system::{is_dir, mkdir, stat};
 use mod_logger::{LogDestination, Logger, NO_STREAM};
 
 const S1_XTRA_FS_SIZE: u64 = 10 * 1024 * 1024; // const XTRA_MEM_FREE: u64 = 10 * 1024 * 1024; // 10 MB
+
+// Compares the contents of the files in dir1
+// to the contents of the files that have the same name in dir2.
+fn compare_files(dir1: PathBuf, dir2: PathBuf) -> Result<()> {
+    let files_dir1 = read_dir(dir1).unwrap();
+
+    for dir1_entry in files_dir1 {
+        let file = dir1_entry?;
+        let metadata = file.metadata()?;
+
+        // skip any directories or symlinks
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let dir2_file_path = Path::new(&dir2).join(Path::new(
+            file.path().file_name().unwrap().to_str().as_ref().unwrap(),
+        ));
+
+        let mut dir2_file = match File::open(dir2_file_path.clone()) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::with_context(
+                    ErrorKind::InvState,
+                    &format!(
+                        "Failed to open {} for comparison - {}",
+                        dir2_file_path.as_path().display(),
+                        e
+                    ),
+                ));
+            }
+        };
+
+        let mut dir1_file = match File::open(file.path()) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::with_context(
+                    ErrorKind::InvState,
+                    &format!(
+                        "Failed to open {} for comparison - {}",
+                        file.path().display(),
+                        e
+                    ),
+                ));
+            }
+        };
+
+        if diff_files(&mut dir2_file, &mut dir1_file) {
+            debug!(
+                "Files {} and {} have matching contents",
+                dir2_file_path.as_path().display(),
+                file.path().display()
+            );
+        } else {
+            error!(
+                "Files {} and {} don't have matching contents!",
+                dir2_file_path.as_path().display(),
+                file.path().display()
+            );
+            return Err(Error::with_context(
+                ErrorKind::InvState,
+                "Connection files contents mistmatch detected. Aborting.",
+            ));
+        }
+    }
+
+    // No mismatch found, or directory is empty
+    Ok(())
+}
 
 fn prepare_configs<P1: AsRef<Path>>(
     work_dir: P1,
@@ -91,9 +163,51 @@ fn prepare_configs<P1: AsRef<Path>>(
     ))?;
 
     // If migrating from balenaOS, copy all files from the system-connections file in /mnt/boot
-    // TODO: Check if we should copy them from the boot partition, or from the NM root overlay directory
     if mig_info.os_name().starts_with(BALENA_OS_NAME) {
+        // Check if the files in /etc/NetworkManager/system-connections also exist in /mnt/boot/system-connections
+        // and if they have the same contents
+        let mut compare_result = compare_files(
+            PathBuf::from(BALENA_NETWORK_MANAGER_BIND_MOUNT).join(SYSTEM_CONNECTIONS_DIR),
+            PathBuf::from(BALENA_OS_BOOT_MP).join(SYSTEM_CONNECTIONS_DIR),
+        );
+
+        match compare_result {
+            Ok(()) => {
+                info!(
+                    "OK: Bind-mounted path connection files match the ones in the boot partition."
+                );
+            }
+            Err(why) => {
+                return Err(Error::from_upstream_error(
+                    Box::new(why),
+                    "Bind-mounted path connection files don't match the ones in the boot partition.",
+                ));
+            }
+        }
+
+        // Check if the files in /mnt/boot/system-connections also exist in /etc/NetworkManager/system-connections
+        // and if they have the same contents
+        compare_result = compare_files(
+            PathBuf::from(BALENA_OS_BOOT_MP).join(SYSTEM_CONNECTIONS_DIR),
+            PathBuf::from(BALENA_NETWORK_MANAGER_BIND_MOUNT).join(SYSTEM_CONNECTIONS_DIR),
+        );
+
+        match compare_result {
+            Ok(()) => {
+                info!(
+                    "OK: Boot partition connection files match the ones in the bind-mounted path."
+                );
+            }
+            Err(why) => {
+                return Err(Error::from_upstream_error(
+                    Box::new(why),
+                    "Boot partition connection files don't match the ones in the bind-mounted path.",
+                ));
+            }
+        }
+
         debug!("migrating from balenaOS - copying system-connections files");
+
         let nwmgr_files = read_dir(BALENA_SYSTEM_CONNECTIONS_BOOT_PATH).unwrap();
         for path in nwmgr_files {
             mig_info.add_nwmgr_file(path.unwrap().path());


### PR DESCRIPTION
... and abort the migration if there's any difference between the files in /mnt/boot/system-connections and the ones in the bind-mounted path /etc/NetworkManager/system-connections.

This comparison is performed only during balenaOS to balenaOS migrations.

Change-type: patch

Fixes https://github.com/balena-os/takeover/issues/67

Tested on balenaOS to balenaOS migrations for the Jetson AGX Xavier