### PR TITLE
Refactor connection migration

### DIFF
--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -61,11 +61,11 @@ impl MigrateInfo {
             os_name
         );
 
-        //If no config.json is passed in command line and we're running on balenaOS,
+        // If no config.json is passed in command line and we're running on balenaOS,
         // we can preserve the existing config.json
         let mut config = if let Some(balena_cfg) = opts.config() {
             BalenaCfgJson::new(balena_cfg)?
-        } else if get_os_name()?.starts_with("balenaOS") {
+        } else if get_os_name()?.starts_with(BALENA_OS_NAME) {
             BalenaCfgJson::new("/mnt/boot/config.json")?
         } else {
             match MigrateInfo::get_internal_cfg_json(&opts.work_dir()) {

--- a/src/stage1/migrate_info.rs
+++ b/src/stage1/migrate_info.rs
@@ -1,10 +1,14 @@
+use file_diff::diff_files;
 use log::{debug, error, info, warn};
 use nix::mount::umount;
-use std::fs::{read_to_string, remove_dir_all, OpenOptions};
+use std::fs::{read_dir, read_to_string, remove_dir_all, File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::ptr::read_volatile;
 
-use crate::common::defs::BACKUP_ARCH_NAME;
+use crate::common::defs::{
+    BACKUP_ARCH_NAME, BALENA_NETWORK_MANAGER_BIND_MOUNT, BALENA_OS_BOOT_MP, BALENA_OS_NAME,
+    BALENA_SYSTEM_CONNECTIONS_BOOT_PATH, BALENA_SYSTEM_PROXY_BOOT_PATH, SYSTEM_CONNECTIONS_DIR,
+};
 use crate::common::path_append;
 use crate::{
     common::{file_exists, get_os_name, options::Options, Error, ErrorKind, Result, ToError},
@@ -142,8 +146,66 @@ impl MigrateInfo {
             Vec::new()
         };
 
-        let nwmgr_files = Vec::from(opts.nwmgr_cfg());
-        let system_proxy_files = Vec::new();
+        let mut nwmgr_files = Vec::from(opts.nwmgr_cfg());
+
+        // Migration of system connections has some special handling when
+        // migrating from balenaOS.
+        if os_name.starts_with(BALENA_OS_NAME) {
+            // Check if the files in /etc/NetworkManager/system-connections also exist in /mnt/boot/system-connections
+            // and if they have the same contents
+            let mut compare_result = compare_files(
+                PathBuf::from(BALENA_NETWORK_MANAGER_BIND_MOUNT).join(SYSTEM_CONNECTIONS_DIR),
+                PathBuf::from(BALENA_OS_BOOT_MP).join(SYSTEM_CONNECTIONS_DIR),
+            );
+
+            match compare_result {
+                Ok(()) => {
+                    info!(
+                    "OK: Bind-mounted path connection files match the ones in the boot partition."
+                );
+                }
+                Err(why) => {
+                    return Err(Error::from_upstream_error(
+                    Box::new(why),
+                    "Bind-mounted path connection files don't match the ones in the boot partition.",
+                ));
+                }
+            }
+
+            // Check if the files in /mnt/boot/system-connections also exist in /etc/NetworkManager/system-connections
+            // and if they have the same contents
+            compare_result = compare_files(
+                PathBuf::from(BALENA_OS_BOOT_MP).join(SYSTEM_CONNECTIONS_DIR),
+                PathBuf::from(BALENA_NETWORK_MANAGER_BIND_MOUNT).join(SYSTEM_CONNECTIONS_DIR),
+            );
+
+            match compare_result {
+                Ok(()) => {
+                    info!(
+                    "OK: Boot partition connection files match the ones in the bind-mounted path."
+                );
+                }
+                Err(why) => {
+                    return Err(Error::from_upstream_error(
+                    Box::new(why),
+                    "Boot partition connection files don't match the ones in the bind-mounted path.",
+                ));
+                }
+            }
+
+            // If migrating from balenaOS, copy all files from /mnt/boot/system-connections
+            if os_name.starts_with(BALENA_OS_NAME) {
+                debug!("migrating from balenaOS - marking system-connections files for copying");
+                let nwmgr_dir_entries = read_dir(BALENA_SYSTEM_CONNECTIONS_BOOT_PATH)
+                    .upstream_with_context(&format!(
+                        "Getting NetworkManager connections from '{}'",
+                        BALENA_SYSTEM_CONNECTIONS_BOOT_PATH
+                    ))?;
+                for path in nwmgr_dir_entries {
+                    nwmgr_files.push(path?.path());
+                }
+            }
+        }
 
         if nwmgr_files.is_empty() && wifis.is_empty() {
             if opts.no_nwmgr_check() {
@@ -155,6 +217,22 @@ impl MigrateInfo {
                     "No Network manager files were found, the device might not be able to come online"
                 );
                 return Err(Error::displayed());
+            }
+        }
+
+        let mut system_proxy_files = Vec::new();
+
+        // If migrating from balenaOS, copy all files from /mnt/boot/system-proxy
+        if os_name.starts_with(BALENA_OS_NAME) {
+            debug!("migrating from balenaOS - marking system-proxy files for copying");
+            let system_proxy_dir_entries = read_dir(BALENA_SYSTEM_PROXY_BOOT_PATH)
+                .upstream_with_context(&format!(
+                    "Getting system proxy connections from '{}'",
+                    BALENA_SYSTEM_PROXY_BOOT_PATH
+                ))?;
+
+            for sys_proxy_path in system_proxy_dir_entries {
+                system_proxy_files.push(sys_proxy_path?.path());
             }
         }
 
@@ -388,4 +466,73 @@ impl MigrateInfo {
             ))
         }
     }
+}
+
+// Compares the contents of the files in dir1
+// to the contents of the files that have the same name in dir2.
+fn compare_files(dir1: PathBuf, dir2: PathBuf) -> Result<()> {
+    let files_dir1 = read_dir(dir1).unwrap();
+
+    for dir1_entry in files_dir1 {
+        let file = dir1_entry?;
+        let metadata = file.metadata()?;
+
+        // skip any directories or symlinks
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let dir2_file_path = Path::new(&dir2).join(Path::new(
+            file.path().file_name().unwrap().to_str().as_ref().unwrap(),
+        ));
+
+        let mut dir2_file = match File::open(dir2_file_path.clone()) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::with_context(
+                    ErrorKind::InvState,
+                    &format!(
+                        "Failed to open {} for comparison - {}",
+                        dir2_file_path.as_path().display(),
+                        e
+                    ),
+                ));
+            }
+        };
+
+        let mut dir1_file = match File::open(file.path()) {
+            Ok(f) => f,
+            Err(e) => {
+                return Err(Error::with_context(
+                    ErrorKind::InvState,
+                    &format!(
+                        "Failed to open {} for comparison - {}",
+                        file.path().display(),
+                        e
+                    ),
+                ));
+            }
+        };
+
+        if diff_files(&mut dir2_file, &mut dir1_file) {
+            debug!(
+                "Files {} and {} have matching contents",
+                dir2_file_path.as_path().display(),
+                file.path().display()
+            );
+        } else {
+            error!(
+                "Files {} and {} don't have matching contents!",
+                dir2_file_path.as_path().display(),
+                file.path().display()
+            );
+            return Err(Error::with_context(
+                ErrorKind::InvState,
+                "Connection files contents mistmatch detected. Aborting.",
+            ));
+        }
+    }
+
+    // No mismatch found, or directory is empty
+    Ok(())
 }

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -105,7 +105,7 @@ fn get_required_space(s2_cfg: &Stage2Config) -> Result<u64> {
     );
 
     for dir_entry in read_dir(&nwmgr_path).upstream_with_context(&format!(
-        "Failed to read drectory '{}'",
+        "Failed to read directory '{}'",
         nwmgr_path.display()
     ))? {
         match dir_entry {
@@ -215,7 +215,7 @@ fn copy_files(s2_cfg: &Stage2Config) -> Result<()> {
         }
 
         for dir_entry in read_dir(&config_file_path).upstream_with_context(&format!(
-            "Failed to read drectory '{}'",
+            "Failed to read directory '{}'",
             config_file_path.display()
         ))? {
             match dir_entry {


### PR DESCRIPTION
This PR is just refactoring the code in order to make it simpler to understand and maintain in the long run. There shall be no functional changes here.

There are two commits with small changes (fixing typos, and using constant), and two other commits with more substantial changes to system connections migrations:

1. Keep the code better aligned with previously existing code that did similar things.
2. Factor the code comparing the two system connection locations to a separate function.

**Testing:** I ran three migration scenarios manually, all working fine:

1. NUC to Generic amd64. (And here I did some variations to try the cases in which we detect discrepancies between the two locations with system connections.)
2. From 64-bit Devuan to 64-bit balenaOS on a Pi 3.
3. From 32-bit Raspberry Pi OS to 64-bit balenaOS on a Pi 3.

For convenience, here's a copy of the commit messages for the two larger commits.

-----

We have recently added code to migrate system connection and proxy
configs during balenaOS-to-balenaOS migrations. That code was working
correctly, but it wasn't following the same patterns as similar
previously existing code followed.

This commit refactors the new code to follow the established patterns,
which shall make takeover maintenance easier.

Being more specific, the idea is to make the new code more aligned with
the code we already had for handling WiFi networks:

1. In `migrate_info.rs` populate the `MigrateInfo` fields. This is what
   we were already doing for `wifis`.
4. In `stage1.rs` do the actual copying. Again, this is similar to what
   we did for `wifis``: this is the same place we currently already
   create the connection files for WiFi.

In summary, this is just trying to keep similar operations closer
together in the code, which hopefully will help future maintainers to
understand it.

-----

This commit just factors out the comparison of system connection
locations into a separate function. This keeps the main migration code
path cleaner and easier to follow.
