### PR TITLE
Handle races! :racehorse: 

### DIFF
--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -196,6 +196,13 @@ fn parse_status(base_path: &Path) -> Result<HashMap<String, String>> {
             }
             Ok(result)
         }
+        // Files do get removed from the /proc filesystem as processes exit, so
+        // we can safely ignore "file not found" errors here. Other errors may
+        // indicate something serious, so we report them.
+        Err(why) if why.kind() == io::ErrorKind::NotFound => {
+            debug!("continue after harmless read_to_string error: {}", why);
+            Ok(HashMap::new())
+        }
         Err(why) => Err(Error::from_upstream(
             Box::new(why),
             &format!("Failed to read process status: '{}'", status_path.display()),


### PR DESCRIPTION
This PR solves a number of different (but related) issues caused by race conditions when iterating over the entries in `/proc`. Iterating over `/proc` and doing some operation over its entries is inherently racy, because entries on the `proc` filesystem can vanish at any time as processes die.

There are 4 commits here, each dealing with one different function call than can fail because of race conditions:

1. An `lstat()` would fail if a process exited or closed an open file
2. As above, but for a `read_link()` call
3. Another `read_lilnk()` (for `/proc/PID/root`) would fail with processes exiting
4. Ditto, for a `read_to_string()` call reading `/proc/PID/status`

Most of these cases were handled the same way: if the error from the call is a "file not found", we just ignore the error and keep running. This will skip the code that would do something with this entry, but this seems to be safe in every case. (For example, we skip killing the corresponding process -- which in this case is already dead anyway).

Errors different from "file not found" keep being handled as before: we log them, and return the error to the caller (which eventually causes the migration process to be aborted).

Case 3 in the list above was handled a bit differently: the information being read wasn't really used anywhere, so we simply removed the racy read.

Solves #62 . All the different errors reported on that issue were reproduced (see below) and are addressed by this PR.

### Testing

I run migrations from RaspiOS to balenaOS, and a NUC-to-generic-amd64 DT change and they both worked as before.

I managed to force-reproduce all the cases dealt with in this PR, using the patch below. Without this PR, the issues would abort the migration, even though it would be OK to keep it running. With the PR, all cases logged the expected debug info, and the migration proceeded to the end.

This can be applied on top of 5386618f02927bf952ffea2fc5ab0a1b7aa3d7d8

<details>

```patch
commit 2b57067dc1716c4e9ed9da81eb6a859da09b052b
Author: Leandro Motta Barros <leandro@balena.io>
Date:   Wed Apr 24 17:12:38 2024 -0300

    [TEST] Add code to reproduce the race condition issues

diff --git a/src/common/system.rs b/src/common/system.rs
index c8dac28..8cf9220 100644
--- a/src/common/system.rs
+++ b/src/common/system.rs
@@ -220,6 +220,10 @@ pub(crate) fn get_process_info_for(pid: i32, directory: Option<&Path>) -> Result
     };
 
     let exec_path = path_append(directory, "exe");
+    // // RACE REPRO, Case 4
+    // if pid == race_repro_pid() {
+    //     race_repro_kill(libc::SIGKILL)?;
+    // }
     let executable = match read_link(&exec_path) {
         Ok(link_path) => Some(link_path),
         Err(why) if why.kind() == io::ErrorKind::NotFound => None,
@@ -234,6 +238,10 @@ pub(crate) fn get_process_info_for(pid: i32, directory: Option<&Path>) -> Result
         }
     };
 
+    // // RACE REPRO, Case 5
+    // if pid == race_repro_pid() {
+    //     race_repro_kill(libc::SIGKILL)?;
+    // }
     Ok(ProcessInfo {
         process_id: pid,
         status: parse_status(directory)?,
@@ -309,9 +317,26 @@ pub(crate) fn fuser<P: AsRef<Path>>(
                                         curr_path.display()
                                     ))?;
 
+                                // if curr_pid == race_repro_pid() {
+                                //     trace!(
+                                //         "race repro, will kill process {}; curr_path = {}",
+                                //         race_repro_pid(),
+                                //         curr_path.display()
+                                //     );
+
+                                //     // RACE REPRO, Case 1
+                                //     // race_repro_kill(libc::SIGKILL)?;
+
+                                //     // RACE REPRO, Case 2
+                                //     // race_repro_kill(libc::SIGTERM)?;
+                                // }
+
                                 match lstat(curr_path.as_path()) {
                                     Ok(stat_info) => {
                                         if is_lnk(&stat_info) {
+
+                                            // // RACE REPRO, Case 3
+                                            // race_repro_kill(libc::SIGKILL)?;
                                             match read_link(curr_path.as_path()) {
                                                 Ok(link_data) => {
                                                     debug!(
@@ -806,3 +831,66 @@ pub(crate) fn copy_dir<P1: AsRef<Path>, P2: AsRef<Path>>(source: P1, dest: P2) -
         ))
     }
 }
+
+//
+// RACE REPRO: Reproduction of race conditions when iterating over the list of
+// processes
+//
+// race_repro_init() spawns a process that keeps a file open.
+//
+// Later we can reproduce the issues by calling race_repro_kill() at strategic
+// points passing either:
+//
+// * libc::SIGTERM to close the file while keeping the process alive
+// * libc::SIGKILL to kill the process (and close the file as a side effect)
+//
+
+pub(crate) static mut RACE_REPRO_PID: i32 = -1;
+
+pub(crate) fn race_repro_init() -> Result<()> {
+    trace!("enter race_repro_init");
+
+    let proc = std::process::Command::new("/bin/sh")
+        .args([
+            "-c",
+            "exec 3< /mnt/old_root/etc/os-release; trap \"exec 3<&-\" TERM; while true; do sleep 1; done",
+        ])
+        .spawn()?;
+
+    unsafe {
+        RACE_REPRO_PID = proc.id() as i32;
+        trace!("leave race_repro_init with pid = {}", RACE_REPRO_PID);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn race_repro_kill(sig: libc::c_int) -> Result<()> {
+    unsafe {
+        trace!(
+            "enter race_repro_kill, sig = {}, race_repro_pid = {}",
+            sig,
+            RACE_REPRO_PID
+        );
+
+        let rc = libc::kill(RACE_REPRO_PID, sig);
+        if rc != 0 {
+            warn!(
+                "race_repro_kill(), failed to kill process {}, return code: {}",
+                RACE_REPRO_PID, rc
+            );
+        }
+        if sig == libc::SIGKILL {
+            libc::waitpid(RACE_REPRO_PID, std::ptr::null_mut(), 0);
+        } else {
+            sleep(Duration::from_secs(1));
+        }
+    }
+
+    trace!("leave race_repro_kill");
+    Ok(())
+}
+
+pub(crate) fn race_repro_pid() -> i32 {
+    unsafe { RACE_REPRO_PID }
+}
diff --git a/src/stage1.rs b/src/stage1.rs
index 6f173bd..010d752 100644
--- a/src/stage1.rs
+++ b/src/stage1.rs
@@ -267,7 +267,7 @@ fn prepare(opts: &Options, mig_info: &mut MigrateInfo) -> Result<()> {
     // calculate required memory
 
     let mut req_space: u64 = 0;
-    let mut copy_commands = vec![DD_CMD];
+    let mut copy_commands = vec![DD_CMD, "sh", "sleep", "true"]; // RACE REPRO: We'll need some extra goodies during stage 2.
 
     // If device is a Jetson Xavier, don't copy over efibootmgr because the old L4T does not use EFI
     if mig_info.is_x86()
diff --git a/src/stage2.rs b/src/stage2.rs
index 3ab219b..de118fe 100644
--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -1281,6 +1281,16 @@ pub fn stage2(opts: &Options) -> ! {
 
     setup_logging(s2_config.log_dev());
 
+    // RACE REPRO
+    let race_repro_init_result = crate::common::system::race_repro_init();
+    if race_repro_init_result.is_err() {
+        error!(
+            "Race repro initialization failed! {}",
+            race_repro_init_result.unwrap_err()
+        );
+        reboot();
+    }
+
     match kill_procs(opts.s2_log_level()) {
         Ok(_) => (),
         Err(why) => {
```
</details>
