### PR TITLE
Check earlier for log device

### DIFF
--- a/src/stage1/checks.rs
+++ b/src/stage1/checks.rs
@@ -1,15 +1,36 @@
 use log::error;
 
+use super::{block_device_info::BlockDeviceInfo, get_block_dev_info, get_log_device};
 use crate::common::{is_admin, Error, Options, Result};
 
 /// Performs checks to ensure that the program can run properly with the
 /// provided command-line options. Returns an error if the program cannot run
 /// for some reason.
-pub(crate) fn do_early_checks(_opts: &Options) -> Result<()> {
+pub(crate) fn do_early_checks(opts: &Options) -> Result<()> {
     if !is_admin()? {
         error!("please run this program as root");
         return Err(Error::displayed());
     }
 
+    let block_dev_info = get_block_dev_info()?;
+
+    if !check_log_device(opts, &block_dev_info) {
+        error!("the requested log device is not suitable for writing stage2 logs");
+        return Err(Error::displayed());
+    }
+
     Ok(())
+}
+
+/// Checks if the log device requested with `--log-device` is suitable for
+/// writing stage2 logs.
+fn check_log_device(opts: &Options, block_dev_info: &BlockDeviceInfo) -> bool {
+    if opts.log_to().is_none() {
+        // No log device requested: that's fine!
+        return true;
+    };
+
+    // But if the user requested a log device, we must be able to get it. If we
+    // can't, *that* is a problem!
+    get_log_device(opts, block_dev_info).is_some()
 }

--- a/src/stage1/checks.rs
+++ b/src/stage1/checks.rs
@@ -1,0 +1,15 @@
+use log::error;
+
+use crate::common::{is_admin, Error, Options, Result};
+
+/// Performs checks to ensure that the program can run properly with the
+/// provided command-line options. Returns an error if the program cannot run
+/// for some reason.
+pub(crate) fn do_early_checks(_opts: &Options) -> Result<()> {
+    if !is_admin()? {
+        error!("please run this program as root");
+        return Err(Error::displayed());
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Previously, we'd check for the log device (passed with `--log-to`) only
after the user confirmed to proceed with the migration. And then, if the
device was not valid, takeover would keep running without storing the
stage 2 logs anywhere.

In other words, a mistake in the command-line arguments could cause
important logs to be lost.

With this commit, we check the the log device at a much earlier point
(before asking the user for confirmation to proceed), and if the device
provided is no good, we log an error message and exit. This allows the
user to fix the command-line arguments and run again.
