### PR TITLE
stage1/block_device_info: Improve failure logs for empty partitions

### DIFF
--- a/src/stage1/block_device_info/partition.rs
+++ b/src/stage1/block_device_info/partition.rs
@@ -102,7 +102,11 @@ impl PartitionInfo {
         } else {
             Err(Error::with_context(
                 ErrorKind::InvParam,
-                &format!("Could not parse blkid output: '{}'", cmd_res),
+                &format!(
+                    "Empty or unexpected blkid output '{}' for path '{}'",
+                    cmd_res,
+                    &*device.as_ref().to_string_lossy()
+                ),
             ))
         }
     }


### PR DESCRIPTION
If the system contains an empty partition, one that has no filesystem or for which blkid returns an empty output or error, let's log that.

This can be reproduced by trying to provision with a balenaOS flasher image which has no filesystem on /dev/sda5.

Change-type: patch