### PR TITLE
Fix use of elapsed seconds

### DIFF
--- a/src/common/stream_progress.rs
+++ b/src/common/stream_progress.rs
@@ -41,15 +41,15 @@ impl<T: Read> Read for StreamProgress<T> {
                         "{} of {} read in {} seconds @{}/sec ",
                         format_size_with_unit(self.bytes_read),
                         format_size_with_unit(size),
-                        Instant::now().duration_since(self.start_time).as_secs(),
-                        format_size_with_unit(self.bytes_read / elapsed),
+                        elapsed,
+                        format_size_with_unit(self.bytes_read / elapsed.max(1)),
                     )
                 } else {
                     format!(
                         "{} read in {} seconds @{}/sec ",
                         format_size_with_unit(self.bytes_read),
-                        Instant::now().duration_since(self.start_time).as_secs(),
-                        format_size_with_unit(self.bytes_read / elapsed),
+                        elapsed,
+                        format_size_with_unit(self.bytes_read / elapsed.max(1)),
                     )
                 };
 
@@ -77,15 +77,15 @@ impl<T: Read> Read for StreamProgress<T> {
                     "{} of {} read in {} seconds @{}/sec ",
                     format_size_with_unit(self.bytes_read),
                     format_size_with_unit(size),
-                    Instant::now().duration_since(self.start_time).as_secs(),
-                    format_size_with_unit(self.bytes_read / elapsed),
+                    elapsed,
+                    format_size_with_unit(self.bytes_read / elapsed.max(1)),
                 )
             } else {
                 format!(
                     "{} read in {} seconds @{}/sec ",
                     format_size_with_unit(self.bytes_read),
-                    Instant::now().duration_since(self.start_time).as_secs(),
-                    format_size_with_unit(self.bytes_read / elapsed),
+                    elapsed,
+                    format_size_with_unit(self.bytes_read / elapsed.max(1)),
                 )
             };
 

--- a/src/stage2.rs
+++ b/src/stage2.rs
@@ -1222,7 +1222,7 @@ fn flash_external(target_path: &Path, image_path: &Path, dd_cmd: &str) -> FlashS
                     tot_bytes,
                     format_size_with_unit(tot_bytes),
                     elapsed,
-                    format_size_with_unit(tot_bytes / elapsed),
+                    format_size_with_unit(tot_bytes / elapsed.max(1)),
                 );
             } else {
                 error!("Failed to retrieve dd stdin");


### PR DESCRIPTION
Includes a divide by zero error.

Before:
```
$ ./takeover -d -c config.json --version 5.3.4+rev3
2024-06-30 15:06:43 INFO  Detected OS Architecture is ARMHF
2024-06-30 15:06:43 INFO  Detected OS name is Debian GNU/Linux 9 (stretch)
2024-06-30 15:06:43 INFO  Detected device type: Beaglebone Black, running Debian GNU/Linux 9 (stretch)
2024-06-30 15:06:43 INFO  config.json is for device type beaglebone-black
2024-06-30 15:06:44 INFO  Selected version 5.3.4+rev3 for download
2024-06-30 15:06:44 INFO  Downloading Balena OS image, selected version is: '5.3.4+rev3'
thread 'main' panicked at src/common/stream_progress.rs:52:47:
attempt to divide by zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
After:
```
$ ./takeover -d -c config.json --version 5.3.4+rev3
2024-06-30 21:16:35 INFO  Detected OS Architecture is AMD64
2024-06-30 21:16:35 INFO  Detected device type: X68_64/Intel Nuc, running Ubuntu 22.04.4 LTS
2024-06-30 21:16:35 INFO  config.json is for device type beaglebone-black
2024-06-30 21:16:36 INFO  Selected version 5.3.4+rev3 for download
2024-06-30 21:16:36 INFO  Downloading Balena OS image, selected version is: '5.3.4+rev3'
2024-06-30 21:16:36 INFO  37 B read in 0 seconds @37 B/sec 
2024-06-30 21:16:36 INFO  The balena OS image was successfully written to '/home/kbee/dev/takeover/share/test/balena-cloud-beaglebone-black-5.3.4+rev3.img.gz'
```
